### PR TITLE
SDK: Add `test-utils.ts` with `createMockFetch()` helper

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,6 +26,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./test-utils": {
+      "types": "./dist/test-utils.d.ts",
+      "import": "./dist/test-utils.js"
     }
   },
   "publishConfig": {

--- a/packages/sdk/src/test-utils.test.ts
+++ b/packages/sdk/src/test-utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { Forge } from "./forge.ts";
+import { createMockFetch } from "./test-utils.ts";
+
+describe("createMockFetch", () => {
+  it("should return a function", () => {
+    const mockFetch = createMockFetch(() => ({}));
+    expect(typeof mockFetch).toBe("function");
+  });
+
+  it("should call the handler with a string URL", async () => {
+    let capturedUrl: string | undefined;
+    const mockFetch = createMockFetch((url) => {
+      capturedUrl = url;
+      return { servers: [] };
+    });
+    await mockFetch("https://example.com/api/v1/servers", undefined);
+    expect(capturedUrl).toBe("https://example.com/api/v1/servers");
+  });
+
+  it("should call the handler with a URL object coerced to string", async () => {
+    let capturedUrl: string | undefined;
+    const mockFetch = createMockFetch((url) => {
+      capturedUrl = url;
+      return {};
+    });
+    await mockFetch(new URL("https://example.com/api/v1/servers"), undefined);
+    expect(capturedUrl).toBe("https://example.com/api/v1/servers");
+  });
+
+  it("should call the handler with a Request object's URL", async () => {
+    let capturedUrl: string | undefined;
+    const mockFetch = createMockFetch((url) => {
+      capturedUrl = url;
+      return {};
+    });
+    const request = new Request("https://example.com/api/v1/servers");
+    await mockFetch(request, undefined);
+    expect(capturedUrl).toBe("https://example.com/api/v1/servers");
+  });
+
+  it("should pass init to the handler", async () => {
+    let capturedInit: RequestInit | undefined;
+    const mockFetch = createMockFetch((_, init) => {
+      capturedInit = init;
+      return {};
+    });
+    const init: RequestInit = { method: "POST", body: JSON.stringify({ test: true }) };
+    await mockFetch("https://example.com/api", init);
+    expect(capturedInit).toBe(init);
+  });
+
+  it("should return a Response with JSON body", async () => {
+    const data = { servers: [{ id: 1, name: "web-01" }] };
+    const mockFetch = createMockFetch(() => data);
+    const response = await mockFetch("https://example.com/api/v1/servers", undefined);
+    expect(response).toBeInstanceOf(Response);
+    const json = await response.json();
+    expect(json).toEqual(data);
+  });
+
+  it("should return a Response with status 200", async () => {
+    const mockFetch = createMockFetch(() => ({}));
+    const response = await mockFetch("https://example.com/api", undefined);
+    expect(response.status).toBe(200);
+  });
+
+  it("should return a Response with application/json content type", async () => {
+    const mockFetch = createMockFetch(() => ({}));
+    const response = await mockFetch("https://example.com/api", undefined);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("should work with Forge SDK for listing resources", async () => {
+    const mockServers = { servers: [{ id: 1, name: "web-01" }] };
+    const mockFetch = createMockFetch(() => mockServers);
+    const forge = new Forge("test-token", { fetch: mockFetch });
+    const servers = await forge.servers.list();
+    expect(servers).toEqual(mockServers.servers);
+  });
+});

--- a/packages/sdk/src/test-utils.ts
+++ b/packages/sdk/src/test-utils.ts
@@ -1,0 +1,39 @@
+import { vi } from "vitest";
+
+/**
+ * Create a mock `fetch` function for use in SDK tests.
+ *
+ * The handler receives the request URL and init options, and should return
+ * the data to be serialised as JSON in the response body.
+ *
+ * @param handler A function that receives `(url, init)` and returns response data.
+ * @returns A vitest mock function compatible with the `fetch` signature.
+ *
+ * @example
+ * ```ts
+ * import { describe, it, expect } from 'vitest';
+ * import { Forge } from '@studiometa/forge-sdk';
+ * import { createMockFetch } from '@studiometa/forge-sdk/test-utils';
+ *
+ * describe('my feature', () => {
+ *   it('lists servers', async () => {
+ *     const mockFetch = createMockFetch(() => ({ servers: [] }));
+ *     const forge = new Forge('test-token', { fetch: mockFetch });
+ *     const servers = await forge.servers.list();
+ *     expect(servers).toEqual([]);
+ *   });
+ * });
+ * ```
+ */
+export function createMockFetch(
+  handler: (url: string, init?: RequestInit) => unknown,
+): typeof fetch {
+  return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    const data = handler(urlStr, init);
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}

--- a/packages/sdk/vite.config.ts
+++ b/packages/sdk/vite.config.ts
@@ -4,8 +4,8 @@ import { createBuildConfig, createTestConfig } from "../../vite.config.base.ts";
 
 export default defineConfig({
   build: createBuildConfig({
-    entry: { index: "./src/index.ts" },
-    external: [/^@studiometa\/forge-api/],
+    entry: { index: "./src/index.ts", "test-utils": "./src/test-utils.ts" },
+    external: [/^@studiometa\/forge-api/, "vitest"],
   }),
   test: createTestConfig({
     name: "sdk",


### PR DESCRIPTION
Closes #16

## Changes

- Added `packages/sdk/src/test-utils.ts` with `createMockFetch()` helper function
- Added `packages/sdk/src/test-utils.test.ts` with 9 tests covering all branches (string URL, URL object, Request object, init forwarding, response shape)
- Updated `packages/sdk/package.json` to expose `@studiometa/forge-sdk/test-utils` in the `exports` map with types + import
- Updated `packages/sdk/vite.config.ts` to build `test-utils` as a separate entry (externals include `vitest`)

## Testing

- 1 new test file (`test-utils.test.ts`) with 9 tests
- Coverage: 100% statements/branches/functions/lines for the SDK package
- All package coverage thresholds passing