### PR TITLE
SDK: Add BaseCollection abstract class

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,7 @@
 // Laravel Forge TypeScript SDK — fluent, chainable, fully-typed API client
 
 export { Forge } from "./forge.ts";
+export { BaseCollection } from "./resources/base.ts";
 export { CertificatesCollection } from "./resources/certificates.ts";
 export { DaemonsCollection } from "./resources/daemons.ts";
 export { DatabasesCollection } from "./resources/databases.ts";

--- a/packages/sdk/src/resources/base.test.ts
+++ b/packages/sdk/src/resources/base.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { HttpClient } from "@studiometa/forge-api";
+
+import { BaseCollection } from "./base.ts";
+
+function createClient(): HttpClient {
+  return new HttpClient({
+    token: "test",
+    fetch: async () =>
+      ({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+        text: async () => "{}",
+      }) as Response,
+  });
+}
+
+class TestCollection extends BaseCollection {
+  getClient(): HttpClient {
+    return this.client;
+  }
+}
+
+describe("BaseCollection", () => {
+  it("should store the client as a protected property", () => {
+    const client = createClient();
+    const collection = new TestCollection(client);
+
+    expect(collection.getClient()).toBe(client);
+  });
+
+  it("should allow subclasses to use the client", async () => {
+    const client = createClient();
+    const collection = new TestCollection(client);
+
+    expect(collection.getClient()).toBeInstanceOf(HttpClient);
+  });
+});

--- a/packages/sdk/src/resources/base.ts
+++ b/packages/sdk/src/resources/base.ts
@@ -1,0 +1,13 @@
+import type { HttpClient } from "@studiometa/forge-api";
+
+/**
+ * Abstract base class for resource collections.
+ * Provides a shared `client` property to avoid duplication across all collection classes.
+ */
+export abstract class BaseCollection {
+  protected readonly client: HttpClient;
+
+  constructor(client: HttpClient) {
+    this.client = client;
+  }
+}

--- a/packages/sdk/src/resources/certificates.ts
+++ b/packages/sdk/src/resources/certificates.ts
@@ -6,6 +6,8 @@ import type {
   CertificatesResponse,
 } from "@studiometa/forge-api";
 
+import { BaseCollection } from "./base.ts";
+
 /**
  * Collection of SSL certificates for a site.
  *
@@ -16,13 +18,15 @@ import type {
  * const certs = await forge.server(123).site(456).certificates.list();
  * ```
  */
-export class CertificatesCollection {
+export class CertificatesCollection extends BaseCollection {
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
     private readonly siteId: number,
-  ) {}
+  ) {
+    super(client);
+  }
 
   private get basePath(): string {
     return `/servers/${this.serverId}/sites/${this.siteId}/certificates`;

--- a/packages/sdk/src/resources/daemons.ts
+++ b/packages/sdk/src/resources/daemons.ts
@@ -6,6 +6,8 @@ import type {
   DaemonsResponse,
 } from "@studiometa/forge-api";
 
+import { BaseCollection } from "./base.ts";
+
 /**
  * Collection of daemons (background processes) on a server.
  *
@@ -16,12 +18,14 @@ import type {
  * const daemons = await forge.server(123).daemons.list();
  * ```
  */
-export class DaemonsCollection {
+export class DaemonsCollection extends BaseCollection {
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
-  ) {}
+  ) {
+    super(client);
+  }
 
   private get basePath(): string {
     return `/servers/${this.serverId}/daemons`;

--- a/packages/sdk/src/resources/databases.ts
+++ b/packages/sdk/src/resources/databases.ts
@@ -6,6 +6,8 @@ import type {
   DatabasesResponse,
 } from "@studiometa/forge-api";
 
+import { BaseCollection } from "./base.ts";
+
 /**
  * Collection of databases on a server.
  *
@@ -16,12 +18,14 @@ import type {
  * const dbs = await forge.server(123).databases.list();
  * ```
  */
-export class DatabasesCollection {
+export class DatabasesCollection extends BaseCollection {
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
-  ) {}
+  ) {
+    super(client);
+  }
 
   private get basePath(): string {
     return `/servers/${this.serverId}/databases`;

--- a/packages/sdk/src/resources/deployments.ts
+++ b/packages/sdk/src/resources/deployments.ts
@@ -5,6 +5,8 @@ import type {
   DeploymentsResponse,
 } from "@studiometa/forge-api";
 
+import { BaseCollection } from "./base.ts";
+
 /**
  * Collection of deployments for a site.
  *
@@ -15,13 +17,15 @@ import type {
  * const deployments = await forge.server(123).site(456).deployments.list();
  * ```
  */
-export class DeploymentsCollection {
+export class DeploymentsCollection extends BaseCollection {
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
     private readonly siteId: number,
-  ) {}
+  ) {
+    super(client);
+  }
 
   private get basePath(): string {
     return `/servers/${this.serverId}/sites/${this.siteId}/deployments`;

--- a/packages/sdk/src/resources/servers.ts
+++ b/packages/sdk/src/resources/servers.ts
@@ -9,6 +9,7 @@ import type {
 import { SitesCollection, SiteResource } from "./sites.ts";
 import { DatabasesCollection } from "./databases.ts";
 import { DaemonsCollection } from "./daemons.ts";
+import { BaseCollection } from "./base.ts";
 
 /**
  * Collection of servers.
@@ -27,9 +28,11 @@ import { DaemonsCollection } from "./daemons.ts";
  * const server = await forge.servers.create({ ... });
  * ```
  */
-export class ServersCollection {
+export class ServersCollection extends BaseCollection {
   /** @internal */
-  constructor(private readonly client: HttpClient) {}
+  constructor(client: HttpClient) {
+    super(client);
+  }
 
   /**
    * List all servers.
@@ -129,7 +132,7 @@ export class ServersCollection {
  * const dbs = await forge.server(123).databases.list();
  * ```
  */
-export class ServerResource {
+export class ServerResource extends BaseCollection {
   /** Sites on this server. */
   readonly sites: SitesCollection;
 
@@ -141,9 +144,10 @@ export class ServerResource {
 
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
   ) {
+    super(client);
     this.sites = new SitesCollection(client, serverId);
     this.databases = new DatabasesCollection(client, serverId);
     this.daemons = new DaemonsCollection(client, serverId);

--- a/packages/sdk/src/resources/sites.ts
+++ b/packages/sdk/src/resources/sites.ts
@@ -8,6 +8,7 @@ import type {
 
 import { DeploymentsCollection } from "./deployments.ts";
 import { CertificatesCollection } from "./certificates.ts";
+import { BaseCollection } from "./base.ts";
 
 /**
  * Collection of sites on a server.
@@ -19,12 +20,14 @@ import { CertificatesCollection } from "./certificates.ts";
  * const sites = await forge.server(123).sites.list();
  * ```
  */
-export class SitesCollection {
+export class SitesCollection extends BaseCollection {
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
-  ) {}
+  ) {
+    super(client);
+  }
 
   private get basePath(): string {
     return `/servers/${this.serverId}/sites`;
@@ -113,7 +116,7 @@ export class SitesCollection {
  * const env = await forge.server(123).site(456).env.get();
  * ```
  */
-export class SiteResource {
+export class SiteResource extends BaseCollection {
   /** Deployments for this site. */
   readonly deployments: DeploymentsCollection;
 
@@ -128,10 +131,11 @@ export class SiteResource {
 
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
     private readonly siteId: number,
   ) {
+    super(client);
     this.deployments = new DeploymentsCollection(client, serverId, siteId);
     this.certificates = new CertificatesCollection(client, serverId, siteId);
     this.env = new SiteEnvResource(client, serverId, siteId);
@@ -189,13 +193,15 @@ export class SiteResource {
  * await forge.server(123).site(456).env.update('APP_ENV=production\n...');
  * ```
  */
-export class SiteEnvResource {
+export class SiteEnvResource extends BaseCollection {
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
     private readonly siteId: number,
-  ) {}
+  ) {
+    super(client);
+  }
 
   private get basePath(): string {
     return `/servers/${this.serverId}/sites/${this.siteId}/env`;
@@ -229,13 +235,15 @@ export class SiteEnvResource {
  * await forge.server(123).site(456).nginx.update('server { ... }');
  * ```
  */
-export class SiteNginxResource {
+export class SiteNginxResource extends BaseCollection {
   /** @internal */
   constructor(
-    private readonly client: HttpClient,
+    client: HttpClient,
     private readonly serverId: number,
     private readonly siteId: number,
-  ) {}
+  ) {
+    super(client);
+  }
 
   private get basePath(): string {
     return `/servers/${this.serverId}/sites/${this.siteId}/nginx`;


### PR DESCRIPTION
Closes #14

## Changes

- Added `packages/sdk/src/resources/base.ts` with an abstract `BaseCollection` class that holds a `protected readonly client: HttpClient` field
- Updated all collection classes to extend `BaseCollection` instead of independently declaring a private `client` field:
  - `ServersCollection`, `ServerResource` (servers.ts)
  - `SitesCollection`, `SiteResource`, `SiteEnvResource`, `SiteNginxResource` (sites.ts)
  - `DatabasesCollection` (databases.ts)
  - `DaemonsCollection` (daemons.ts)
  - `DeploymentsCollection` (deployments.ts)
  - `CertificatesCollection` (certificates.ts)
- Exported `BaseCollection` from the SDK's `src/index.ts` barrel

## Testing

- 1 new test file added: `src/resources/base.test.ts`
- Coverage: 100% statements/branches/functions/lines across all SDK files
- All 4 packages pass their coverage thresholds