### PR TITLE
MCP: Wire contextual hints end-to-end in HandlerContext and createResourceHandler

### DIFF
--- a/packages/mcp/src/handlers/certificates.test.ts
+++ b/packages/mcp/src/handlers/certificates.test.ts
@@ -20,10 +20,15 @@ function createMockContext(): HandlerContext {
           ],
           certificate: {
             id: 1,
+            server_id: 1,
+            site_id: 10,
             domain: "example.com",
             type: "letsencrypt",
             active: true,
             status: "installed",
+            request_status: "installed",
+            existing: false,
+            created_at: "2024-01-01",
           },
         }),
         post: async () => ({
@@ -116,5 +121,21 @@ describe("handleCertificates", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toContain("Unknown action");
+  });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleCertificates(
+      "get",
+      { resource: "certificates", action: "get", server_id: "1", site_id: "10", id: "1" },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
   });
 });

--- a/packages/mcp/src/handlers/certificates.ts
+++ b/packages/mcp/src/handlers/certificates.ts
@@ -9,6 +9,7 @@ import {
 import type { ForgeCertificate } from "@studiometa/forge-api";
 
 import { formatCertificate, formatCertificateList } from "../formatters.ts";
+import { getCertificateHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleCertificates = createResourceHandler({
@@ -27,6 +28,10 @@ export const handleCertificates = createResourceHandler({
     create: createCertificate,
     delete: deleteCertificate,
     activate: activateCertificate,
+  },
+  hints: (data, id) => {
+    const cert = data as ForgeCertificate;
+    return getCertificateHints(String(cert.server_id), String(cert.site_id), id);
   },
   formatResult: (action, data, args) => {
     switch (action) {

--- a/packages/mcp/src/handlers/daemons.test.ts
+++ b/packages/mcp/src/handlers/daemons.test.ts
@@ -20,10 +20,12 @@ function createMockContext(): HandlerContext {
           ],
           daemon: {
             id: 1,
+            server_id: 1,
             command: "php artisan queue:work",
             user: "forge",
             processes: 1,
             status: "running",
+            created_at: "2024-01-01",
           },
         }),
         post: async () => ({
@@ -110,5 +112,21 @@ describe("handleDaemons", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toContain("Unknown action");
+  });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleDaemons(
+      "get",
+      { resource: "daemons", action: "get", server_id: "1", id: "1" },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
   });
 });

--- a/packages/mcp/src/handlers/daemons.ts
+++ b/packages/mcp/src/handlers/daemons.ts
@@ -9,6 +9,7 @@ import {
 import type { ForgeDaemon } from "@studiometa/forge-api";
 
 import { formatDaemon, formatDaemonList } from "../formatters.ts";
+import { getDaemonHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleDaemons = createResourceHandler({
@@ -27,6 +28,10 @@ export const handleDaemons = createResourceHandler({
     create: createDaemon,
     delete: deleteDaemon,
     restart: restartDaemon,
+  },
+  hints: (data, id) => {
+    const daemon = data as ForgeDaemon;
+    return getDaemonHints(String(daemon.server_id), id);
   },
   formatResult: (action, data, args) => {
     switch (action) {

--- a/packages/mcp/src/handlers/databases.test.ts
+++ b/packages/mcp/src/handlers/databases.test.ts
@@ -94,4 +94,20 @@ describe("handleDatabases", () => {
     );
     expect(result.isError).toBe(true);
   });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleDatabases(
+      "get",
+      { resource: "databases", action: "get", server_id: "1", id: "1" },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
+  });
 });

--- a/packages/mcp/src/handlers/databases.ts
+++ b/packages/mcp/src/handlers/databases.ts
@@ -3,6 +3,7 @@ import { createDatabase, deleteDatabase, getDatabase, listDatabases } from "@stu
 import type { ForgeDatabase } from "@studiometa/forge-api";
 
 import { formatDatabase, formatDatabaseList } from "../formatters.ts";
+import { getDatabaseHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleDatabases = createResourceHandler({
@@ -19,6 +20,10 @@ export const handleDatabases = createResourceHandler({
     get: getDatabase,
     create: createDatabase,
     delete: deleteDatabase,
+  },
+  hints: (data, id) => {
+    const db = data as ForgeDatabase;
+    return getDatabaseHints(String(db.server_id), id);
   },
   formatResult: (action, data, args) => {
     switch (action) {

--- a/packages/mcp/src/handlers/e2e.test.ts
+++ b/packages/mcp/src/handlers/e2e.test.ts
@@ -364,6 +364,33 @@ describe("E2E: executeToolWithCredentials", () => {
     expect(parsed.id).toBe(1);
   });
 
+  it("should include contextual hints for get action on servers", async () => {
+    const result = await executeToolWithCredentials(
+      "forge",
+      { resource: "servers", action: "get", id: "1" },
+      creds,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    // get action with no compact → includeHints=true → _hints injected
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
+  });
+
+  it("should not include hints when compact=true for get action", async () => {
+    const result = await executeToolWithCredentials(
+      "forge",
+      { resource: "servers", action: "get", id: "1", compact: true },
+      creds,
+    );
+    expect(result.isError).toBeUndefined();
+    // compact=true → text summary, no JSON with _hints
+    const text = result.content[0]!.text;
+    expect(text).toContain("Server: web-1");
+    // text summary is not a JSON object with _hints
+    expect(text).not.toContain("_hints");
+  });
+
   it("should respect explicit compact=true for get action", async () => {
     // Explicit compact=true on a get action → returns text summary
     const result = await executeToolWithCredentials(

--- a/packages/mcp/src/handlers/factory.test.ts
+++ b/packages/mcp/src/handlers/factory.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { ExecutorContext, ExecutorResult } from "@studiometa/forge-core";
 
+import type { ContextualHints } from "../hints.ts";
 import type { HandlerContext } from "./types.ts";
 
 import { createResourceHandler } from "./factory.ts";
@@ -198,5 +199,93 @@ describe("createResourceHandler", () => {
       createMockContext(),
     );
     expect(result.content[0]!.text).toBe("Resource 99 deleted.");
+  });
+
+  it("should inject _hints when action=get, ctx.includeHints=true, and hints config provided", async () => {
+    const mockHints: ContextualHints = {
+      related_resources: [{ resource: "other", description: "desc", example: {} }],
+    };
+    const handler = createResourceHandler({
+      resource: "test",
+      actions: ["get"],
+      executors: {
+        get: async (): Promise<ExecutorResult<{ id: number }>> => ({ data: { id: 1 } }),
+      },
+      hints: (_data, id) => ({ ...mockHints, common_actions: [{ action: id, example: {} }] }),
+    });
+
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handler("get", { resource: "test", action: "get", id: "1" }, ctx);
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources[0].resource).toBe("other");
+    expect(parsed._hints.common_actions[0].action).toBe("1");
+    expect(parsed.id).toBe(1);
+  });
+
+  it("should not inject _hints when hints config is provided but ctx.includeHints is false", async () => {
+    const handler = createResourceHandler({
+      resource: "test",
+      actions: ["get"],
+      executors: {
+        get: async (): Promise<ExecutorResult<{ id: number }>> => ({ data: { id: 2 } }),
+      },
+      hints: () => ({ related_resources: [] }),
+    });
+
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = false;
+
+    const result = await handler("get", { resource: "test", action: "get", id: "2" }, ctx);
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeUndefined();
+    expect(parsed.id).toBe(2);
+  });
+
+  it("should not inject _hints when hints config is not provided", async () => {
+    const handler = createResourceHandler({
+      resource: "test",
+      actions: ["get"],
+      executors: {
+        get: async (): Promise<ExecutorResult<{ id: number }>> => ({ data: { id: 3 } }),
+      },
+    });
+
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handler("get", { resource: "test", action: "get", id: "3" }, ctx);
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeUndefined();
+    expect(parsed.id).toBe(3);
+  });
+
+  it("should use server_id as id for hints when args.id is missing", async () => {
+    let capturedId = "";
+    const handler = createResourceHandler({
+      resource: "test",
+      actions: ["get"],
+      executors: {
+        get: async (): Promise<ExecutorResult<{ server_id: number }>> => ({
+          data: { server_id: 5 },
+        }),
+      },
+      hints: (_data, id) => {
+        capturedId = id;
+        return {};
+      },
+    });
+
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    await handler("get", { resource: "test", action: "get", server_id: "5" }, ctx);
+    expect(capturedId).toBe("5");
   });
 });

--- a/packages/mcp/src/handlers/firewall-rules.test.ts
+++ b/packages/mcp/src/handlers/firewall-rules.test.ts
@@ -21,11 +21,13 @@ function createMockContext(): HandlerContext {
           ],
           rule: {
             id: 1,
+            server_id: 1,
             name: "SSH",
             port: 22,
             type: "allow",
             ip_address: "0.0.0.0",
             status: "created",
+            created_at: "2024-01-01",
           },
         }),
         post: async () => ({
@@ -102,5 +104,21 @@ describe("handleFirewallRules", () => {
       createMockContext(),
     );
     expect(result.isError).toBe(true);
+  });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleFirewallRules(
+      "get",
+      { resource: "firewall-rules", action: "get", server_id: "1", id: "1" },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
   });
 });

--- a/packages/mcp/src/handlers/firewall-rules.ts
+++ b/packages/mcp/src/handlers/firewall-rules.ts
@@ -8,6 +8,7 @@ import {
 import type { ForgeFirewallRule } from "@studiometa/forge-api";
 
 import { formatFirewallRule, formatFirewallRuleList } from "../formatters.ts";
+import { getFirewallRuleHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleFirewallRules = createResourceHandler({
@@ -24,6 +25,10 @@ export const handleFirewallRules = createResourceHandler({
     get: getFirewallRule,
     create: createFirewallRule,
     delete: deleteFirewallRule,
+  },
+  hints: (data, id) => {
+    const rule = data as ForgeFirewallRule;
+    return getFirewallRuleHints(String(rule.server_id), id);
   },
   formatResult: (action, data, args) => {
     switch (action) {

--- a/packages/mcp/src/handlers/index.ts
+++ b/packages/mcp/src/handlers/index.ts
@@ -140,6 +140,7 @@ export async function executeToolWithCredentials(
   const handlerContext: HandlerContext = {
     executorContext,
     compact: compact ?? action !== "get",
+    includeHints: action === "get",
   };
 
   // Route to resource handler with error catching

--- a/packages/mcp/src/handlers/nginx-templates.test.ts
+++ b/packages/mcp/src/handlers/nginx-templates.test.ts
@@ -125,4 +125,20 @@ describe("handleNginxTemplates", () => {
     );
     expect(result.isError).toBe(true);
   });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleNginxTemplates(
+      "get",
+      { resource: "nginx-templates", action: "get", server_id: "1", id: "1" },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
+  });
 });

--- a/packages/mcp/src/handlers/nginx-templates.ts
+++ b/packages/mcp/src/handlers/nginx-templates.ts
@@ -9,6 +9,7 @@ import {
 import type { ForgeNginxTemplate } from "@studiometa/forge-api";
 
 import { formatNginxTemplate, formatNginxTemplateList } from "../formatters.ts";
+import { getNginxTemplateHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleNginxTemplates = createResourceHandler({
@@ -27,6 +28,10 @@ export const handleNginxTemplates = createResourceHandler({
     create: createNginxTemplate,
     update: updateNginxTemplate,
     delete: deleteNginxTemplate,
+  },
+  hints: (data, id) => {
+    const template = data as ForgeNginxTemplate;
+    return getNginxTemplateHints(String(template.server_id), id);
   },
   formatResult: (action, data, args) => {
     switch (action) {

--- a/packages/mcp/src/handlers/recipes.test.ts
+++ b/packages/mcp/src/handlers/recipes.test.ts
@@ -104,4 +104,16 @@ describe("handleRecipes", () => {
     );
     expect(result.isError).toBe(true);
   });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleRecipes("get", { resource: "recipes", action: "get", id: "1" }, ctx);
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
+  });
 });

--- a/packages/mcp/src/handlers/recipes.ts
+++ b/packages/mcp/src/handlers/recipes.ts
@@ -9,6 +9,7 @@ import {
 import type { ForgeRecipe } from "@studiometa/forge-api";
 
 import { formatRecipe, formatRecipeList } from "../formatters.ts";
+import { getRecipeHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleRecipes = createResourceHandler({
@@ -27,6 +28,7 @@ export const handleRecipes = createResourceHandler({
     delete: deleteRecipe,
     run: runRecipe,
   },
+  hints: (_data, id) => getRecipeHints(id),
   formatResult: (action, data, args) => {
     switch (action) {
       case "list":

--- a/packages/mcp/src/handlers/servers.test.ts
+++ b/packages/mcp/src/handlers/servers.test.ts
@@ -116,4 +116,16 @@ describe("handleServers", () => {
     );
     expect(result.isError).toBeUndefined();
   });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleServers("get", { resource: "servers", action: "get", id: "1" }, ctx);
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
+  });
 });

--- a/packages/mcp/src/handlers/servers.ts
+++ b/packages/mcp/src/handlers/servers.ts
@@ -9,6 +9,7 @@ import {
 import type { ForgeServer } from "@studiometa/forge-api";
 
 import { formatServer, formatServerList } from "../formatters.ts";
+import { getServerHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleServers = createResourceHandler({
@@ -27,6 +28,7 @@ export const handleServers = createResourceHandler({
     delete: deleteServer,
     reboot: rebootServer,
   },
+  hints: (_data, id) => getServerHints(id),
   mapOptions: (action, args) => {
     switch (action) {
       case "get":

--- a/packages/mcp/src/handlers/sites.test.ts
+++ b/packages/mcp/src/handlers/sites.test.ts
@@ -12,6 +12,7 @@ function createMockContext(): HandlerContext {
           sites: [{ id: 1, name: "example.com", project_type: "php", status: "installed" }],
           site: {
             id: 1,
+            server_id: 1,
             name: "example.com",
             project_type: "php",
             directory: "/public",
@@ -92,5 +93,21 @@ describe("handleSites", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toContain("Unknown action");
+  });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleSites(
+      "get",
+      { resource: "sites", action: "get", server_id: "1", id: "1" },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
   });
 });

--- a/packages/mcp/src/handlers/sites.ts
+++ b/packages/mcp/src/handlers/sites.ts
@@ -3,6 +3,7 @@ import { createSite, deleteSite, getSite, listSites } from "@studiometa/forge-co
 import type { ForgeSite } from "@studiometa/forge-api";
 
 import { formatSite, formatSiteList } from "../formatters.ts";
+import { getSiteHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleSites = createResourceHandler({
@@ -19,6 +20,10 @@ export const handleSites = createResourceHandler({
     get: getSite,
     create: createSite,
     delete: deleteSite,
+  },
+  hints: (data, id) => {
+    const site = data as ForgeSite;
+    return getSiteHints(String(site.server_id), id);
   },
   mapOptions: (action, args) => {
     switch (action) {

--- a/packages/mcp/src/handlers/ssh-keys.test.ts
+++ b/packages/mcp/src/handlers/ssh-keys.test.ts
@@ -106,4 +106,20 @@ describe("handleSshKeys", () => {
     );
     expect(result.isError).toBe(true);
   });
+
+  it("should inject hints on get when includeHints=true", async () => {
+    const ctx = createMockContext();
+    ctx.compact = false;
+    ctx.includeHints = true;
+
+    const result = await handleSshKeys(
+      "get",
+      { resource: "ssh-keys", action: "get", server_id: "1", id: "1" },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed._hints).toBeDefined();
+    expect(parsed._hints.related_resources).toBeDefined();
+  });
 });

--- a/packages/mcp/src/handlers/ssh-keys.ts
+++ b/packages/mcp/src/handlers/ssh-keys.ts
@@ -3,6 +3,7 @@ import { createSshKey, deleteSshKey, getSshKey, listSshKeys } from "@studiometa/
 import type { ForgeSshKey } from "@studiometa/forge-api";
 
 import { formatSshKey, formatSshKeyList } from "../formatters.ts";
+import { getSshKeyHints } from "../hints.ts";
 import { createResourceHandler } from "./factory.ts";
 
 export const handleSshKeys = createResourceHandler({
@@ -19,6 +20,10 @@ export const handleSshKeys = createResourceHandler({
     get: getSshKey,
     create: createSshKey,
     delete: deleteSshKey,
+  },
+  hints: (data, id) => {
+    const key = data as ForgeSshKey;
+    return getSshKeyHints(String(key.server_id), id);
   },
   formatResult: (action, data, args) => {
     switch (action) {

--- a/packages/mcp/src/handlers/types.ts
+++ b/packages/mcp/src/handlers/types.ts
@@ -14,6 +14,8 @@ export interface ToolResult {
 export interface HandlerContext {
   executorContext: ExecutorContext;
   compact: boolean;
+  /** Whether to include contextual hints in get responses (default: false) */
+  includeHints?: boolean;
 }
 
 /**

--- a/packages/mcp/src/hints.test.ts
+++ b/packages/mcp/src/hints.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { getServerHints, getSiteHints } from "./hints.ts";
+import {
+  getCertificateHints,
+  getDatabaseHints,
+  getDaemonHints,
+  getFirewallRuleHints,
+  getNginxTemplateHints,
+  getRecipeHints,
+  getServerHints,
+  getSiteHints,
+  getSshKeyHints,
+} from "./hints.ts";
 
 describe("getServerHints", () => {
   it("should return related resources and common actions for a server", () => {
@@ -13,6 +23,15 @@ describe("getServerHints", () => {
 
     expect(hints.common_actions).toBeDefined();
     expect(hints.common_actions![0]!.example.id).toBe("123");
+  });
+
+  it("should include ssh-keys and firewall-rules as related resources", () => {
+    const hints = getServerHints("42");
+    const resources = hints.related_resources!.map((r) => r.resource);
+    expect(resources).toContain("ssh-keys");
+    expect(resources).toContain("firewall-rules");
+    expect(resources).toContain("databases");
+    expect(resources).toContain("daemons");
   });
 });
 
@@ -28,5 +47,124 @@ describe("getSiteHints", () => {
 
     expect(hints.common_actions).toBeDefined();
     expect(hints.common_actions![0]!.example.server_id).toBe("123");
+  });
+
+  it("should include certificates, env and nginx as related resources", () => {
+    const hints = getSiteHints("1", "2");
+    const resources = hints.related_resources!.map((r) => r.resource);
+    expect(resources).toContain("certificates");
+    expect(resources).toContain("env");
+    expect(resources).toContain("nginx");
+  });
+});
+
+describe("getDatabaseHints", () => {
+  it("should return hints for a database", () => {
+    const hints = getDatabaseHints("10", "99");
+
+    expect(hints.related_resources).toBeDefined();
+    expect(hints.related_resources![0]!.resource).toBe("databases");
+    expect(hints.related_resources![0]!.example.server_id).toBe("10");
+
+    expect(hints.common_actions).toBeDefined();
+    expect(hints.common_actions![0]!.example.server_id).toBe("10");
+    expect(hints.common_actions![0]!.example.id).toBe("99");
+  });
+});
+
+describe("getDaemonHints", () => {
+  it("should return hints for a daemon", () => {
+    const hints = getDaemonHints("5", "77");
+
+    expect(hints.related_resources).toBeDefined();
+    expect(hints.related_resources![0]!.resource).toBe("daemons");
+    expect(hints.related_resources![0]!.example.server_id).toBe("5");
+
+    expect(hints.common_actions).toBeDefined();
+    // Should have restart and delete actions
+    const actions = hints.common_actions!.map((a) => a.example);
+    const hasRestart = actions.some((a) => (a as Record<string, unknown>).action === "restart");
+    const hasDelete = actions.some((a) => (a as Record<string, unknown>).action === "delete");
+    expect(hasRestart).toBe(true);
+    expect(hasDelete).toBe(true);
+  });
+});
+
+describe("getCertificateHints", () => {
+  it("should return hints for a certificate", () => {
+    const hints = getCertificateHints("3", "7", "55");
+
+    expect(hints.related_resources).toBeDefined();
+    expect(hints.related_resources![0]!.resource).toBe("certificates");
+    expect(hints.related_resources![0]!.example.server_id).toBe("3");
+    expect(hints.related_resources![0]!.example.site_id).toBe("7");
+
+    expect(hints.common_actions).toBeDefined();
+    const actions = hints.common_actions!.map((a) => a.example);
+    const hasActivate = actions.some((a) => (a as Record<string, unknown>).action === "activate");
+    const hasDelete = actions.some((a) => (a as Record<string, unknown>).action === "delete");
+    expect(hasActivate).toBe(true);
+    expect(hasDelete).toBe(true);
+  });
+});
+
+describe("getFirewallRuleHints", () => {
+  it("should return hints for a firewall rule", () => {
+    const hints = getFirewallRuleHints("8", "33");
+
+    expect(hints.related_resources).toBeDefined();
+    expect(hints.related_resources![0]!.resource).toBe("firewall-rules");
+    expect(hints.related_resources![0]!.example.server_id).toBe("8");
+
+    expect(hints.common_actions).toBeDefined();
+    expect(hints.common_actions![0]!.example.id).toBe("33");
+    expect(hints.common_actions![0]!.example.server_id).toBe("8");
+  });
+});
+
+describe("getSshKeyHints", () => {
+  it("should return hints for an SSH key", () => {
+    const hints = getSshKeyHints("9", "44");
+
+    expect(hints.related_resources).toBeDefined();
+    expect(hints.related_resources![0]!.resource).toBe("ssh-keys");
+    expect(hints.related_resources![0]!.example.server_id).toBe("9");
+
+    expect(hints.common_actions).toBeDefined();
+    expect(hints.common_actions![0]!.example.id).toBe("44");
+  });
+});
+
+describe("getRecipeHints", () => {
+  it("should return hints for a recipe", () => {
+    const hints = getRecipeHints("66");
+
+    expect(hints.related_resources).toBeDefined();
+    expect(hints.related_resources![0]!.resource).toBe("recipes");
+
+    expect(hints.common_actions).toBeDefined();
+    const actions = hints.common_actions!.map((a) => a.example);
+    const hasRun = actions.some((a) => (a as Record<string, unknown>).action === "run");
+    const hasDelete = actions.some((a) => (a as Record<string, unknown>).action === "delete");
+    expect(hasRun).toBe(true);
+    expect(hasDelete).toBe(true);
+    expect((hints.common_actions![0]!.example as Record<string, unknown>).id).toBe("66");
+  });
+});
+
+describe("getNginxTemplateHints", () => {
+  it("should return hints for an nginx template", () => {
+    const hints = getNginxTemplateHints("11", "22");
+
+    expect(hints.related_resources).toBeDefined();
+    expect(hints.related_resources![0]!.resource).toBe("nginx-templates");
+    expect(hints.related_resources![0]!.example.server_id).toBe("11");
+
+    expect(hints.common_actions).toBeDefined();
+    const actions = hints.common_actions!.map((a) => a.example);
+    const hasUpdate = actions.some((a) => (a as Record<string, unknown>).action === "update");
+    const hasDelete = actions.some((a) => (a as Record<string, unknown>).action === "delete");
+    expect(hasUpdate).toBe(true);
+    expect(hasDelete).toBe(true);
   });
 });

--- a/packages/mcp/src/hints.ts
+++ b/packages/mcp/src/hints.ts
@@ -42,6 +42,11 @@ export function getServerHints(serverId: string): ContextualHints {
         description: "List firewall rules",
         example: { resource: "firewall-rules", action: "list", server_id: serverId },
       },
+      {
+        resource: "ssh-keys",
+        description: "List SSH keys on this server",
+        example: { resource: "ssh-keys", action: "list", server_id: serverId },
+      },
     ],
     common_actions: [
       {
@@ -87,6 +92,206 @@ export function getSiteHints(serverId: string, siteId: string): ContextualHints 
           action: "deploy",
           server_id: serverId,
           site_id: siteId,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Hints after getting a database.
+ */
+export function getDatabaseHints(serverId: string, databaseId: string): ContextualHints {
+  return {
+    related_resources: [
+      {
+        resource: "databases",
+        description: "List all databases on this server",
+        example: { resource: "databases", action: "list", server_id: serverId },
+      },
+    ],
+    common_actions: [
+      {
+        action: "Delete this database",
+        example: { resource: "databases", action: "delete", server_id: serverId, id: databaseId },
+      },
+    ],
+  };
+}
+
+/**
+ * Hints after getting a daemon.
+ */
+export function getDaemonHints(serverId: string, daemonId: string): ContextualHints {
+  return {
+    related_resources: [
+      {
+        resource: "daemons",
+        description: "List all daemons on this server",
+        example: { resource: "daemons", action: "list", server_id: serverId },
+      },
+    ],
+    common_actions: [
+      {
+        action: "Restart this daemon",
+        example: { resource: "daemons", action: "restart", server_id: serverId, id: daemonId },
+      },
+      {
+        action: "Delete this daemon",
+        example: { resource: "daemons", action: "delete", server_id: serverId, id: daemonId },
+      },
+    ],
+  };
+}
+
+/**
+ * Hints after getting a certificate.
+ */
+export function getCertificateHints(
+  serverId: string,
+  siteId: string,
+  certificateId: string,
+): ContextualHints {
+  return {
+    related_resources: [
+      {
+        resource: "certificates",
+        description: "List all certificates for this site",
+        example: {
+          resource: "certificates",
+          action: "list",
+          server_id: serverId,
+          site_id: siteId,
+        },
+      },
+    ],
+    common_actions: [
+      {
+        action: "Activate this certificate",
+        example: {
+          resource: "certificates",
+          action: "activate",
+          server_id: serverId,
+          site_id: siteId,
+          id: certificateId,
+        },
+      },
+      {
+        action: "Delete this certificate",
+        example: {
+          resource: "certificates",
+          action: "delete",
+          server_id: serverId,
+          site_id: siteId,
+          id: certificateId,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Hints after getting a firewall rule.
+ */
+export function getFirewallRuleHints(serverId: string, ruleId: string): ContextualHints {
+  return {
+    related_resources: [
+      {
+        resource: "firewall-rules",
+        description: "List all firewall rules on this server",
+        example: { resource: "firewall-rules", action: "list", server_id: serverId },
+      },
+    ],
+    common_actions: [
+      {
+        action: "Delete this firewall rule",
+        example: {
+          resource: "firewall-rules",
+          action: "delete",
+          server_id: serverId,
+          id: ruleId,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Hints after getting an SSH key.
+ */
+export function getSshKeyHints(serverId: string, keyId: string): ContextualHints {
+  return {
+    related_resources: [
+      {
+        resource: "ssh-keys",
+        description: "List all SSH keys on this server",
+        example: { resource: "ssh-keys", action: "list", server_id: serverId },
+      },
+    ],
+    common_actions: [
+      {
+        action: "Delete this SSH key",
+        example: { resource: "ssh-keys", action: "delete", server_id: serverId, id: keyId },
+      },
+    ],
+  };
+}
+
+/**
+ * Hints after getting a recipe.
+ */
+export function getRecipeHints(recipeId: string): ContextualHints {
+  return {
+    related_resources: [
+      {
+        resource: "recipes",
+        description: "List all recipes",
+        example: { resource: "recipes", action: "list" },
+      },
+    ],
+    common_actions: [
+      {
+        action: "Run this recipe on servers",
+        example: { resource: "recipes", action: "run", id: recipeId, servers: [] },
+      },
+      {
+        action: "Delete this recipe",
+        example: { resource: "recipes", action: "delete", id: recipeId },
+      },
+    ],
+  };
+}
+
+/**
+ * Hints after getting an nginx template.
+ */
+export function getNginxTemplateHints(serverId: string, templateId: string): ContextualHints {
+  return {
+    related_resources: [
+      {
+        resource: "nginx-templates",
+        description: "List all nginx templates on this server",
+        example: { resource: "nginx-templates", action: "list", server_id: serverId },
+      },
+    ],
+    common_actions: [
+      {
+        action: "Update this nginx template",
+        example: {
+          resource: "nginx-templates",
+          action: "update",
+          server_id: serverId,
+          id: templateId,
+          content: "<nginx config content>",
+        },
+      },
+      {
+        action: "Delete this nginx template",
+        example: {
+          resource: "nginx-templates",
+          action: "delete",
+          server_id: serverId,
+          id: templateId,
         },
       },
     ],


### PR DESCRIPTION
Closes #20

## Changes

- **`types.ts`**: Added `includeHints?: boolean` to `HandlerContext` interface
- **`handlers/index.ts`**: Set `includeHints: action === 'get'` in `executeToolWithCredentials()`
- **`handlers/factory.ts`**: Added `hints` callback option to `ResourceHandlerConfig`; injected `_hints` into non-compact `get` responses when `ctx.includeHints` is true
- **`hints.ts`**: Expanded with 7 new hint functions: `getDatabaseHints`, `getDaemonHints`, `getCertificateHints`, `getFirewallRuleHints`, `getSshKeyHints`, `getRecipeHints`, `getNginxTemplateHints`; also extended `getServerHints` to include `ssh-keys`
- **Handler wiring**: Added `hints` config to `handleServers`, `handleSites`, `handleDatabases`, `handleDaemons`, `handleCertificates`, `handleFirewallRules`, `handleSshKeys`, `handleRecipes`, `handleNginxTemplates`

## Testing

- 9 test files modified (factory, hints, servers, sites, databases, daemons, certificates, firewall-rules, ssh-keys, recipes, nginx-templates, e2e)
- 347 tests passing across the mcp package, 608 total across all packages
- Coverage: 91.71% statements / 84.21% branches / 100% functions / 91.47% lines (thresholds: 80/70/80/80)
- `hints.ts` at 100% coverage
- Edge cases covered: hints injected on `get` with `includeHints=true`, not injected when `compact=true`, not injected when no `hints` config, `server_id` fallback when `args.id` is absent