### PR TITLE
Add forge-cli package — command-line interface following productive-tools CLI structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1491,6 +1491,10 @@
       "resolved": "packages/api",
       "link": true
     },
+    "node_modules/@studiometa/forge-cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@studiometa/forge-core": {
       "resolved": "packages/core",
       "link": true
@@ -4495,6 +4499,28 @@
         "node": ">=18.0.0"
       }
     },
+    "packages/cli": {
+      "name": "@studiometa/forge-cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@studiometa/forge-api": "*",
+        "@studiometa/forge-core": "*"
+      },
+      "bin": {
+        "forge-cli": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "@vitest/coverage-v8": "^4.1.0-beta.4",
+        "typescript": "^5.7.3",
+        "vite": "^8.0.0-beta.14",
+        "vitest": "^4.1.0-beta.4"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
     "packages/core": {
       "name": "@studiometa/forge-core",
       "version": "0.1.0",
@@ -4523,7 +4549,8 @@
         "h3": "^2.0.1-rc.14"
       },
       "bin": {
-        "forge-mcp": "dist/index.js"
+        "forge-mcp": "dist/index.js",
+        "forge-mcp-server": "dist/server.js"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run dev --workspaces",
-    "build": "npm run build -w @studiometa/forge-api && npm run build -w @studiometa/forge-sdk && npm run build -w @studiometa/forge-core && npm run build -w @studiometa/forge-mcp",
+    "build": "npm run build -w @studiometa/forge-api && npm run build -w @studiometa/forge-sdk && npm run build -w @studiometa/forge-core && npm run build -w @studiometa/forge-mcp && npm run build -w @studiometa/forge-cli",
     "test": "vitest run",
     "test:watch": "npm run test:watch --workspaces",
     "test:ci": "npm run test:ci --workspaces --if-present",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@studiometa/forge-cli",
+  "version": "0.1.0",
+  "description": "CLI tool for managing Laravel Forge servers, sites, and deployments",
+  "keywords": [
+    "ai-agent",
+    "api",
+    "automation",
+    "cli",
+    "forge",
+    "laravel",
+    "typescript"
+  ],
+  "license": "MIT",
+  "author": "Studio Meta",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/studiometa/forge-tools",
+    "directory": "packages/cli"
+  },
+  "bin": {
+    "forge-cli": "./dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "dev": "vite build --watch",
+    "build": "vite build && tsc --emitDeclarationOnly",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ci": "vitest run --coverage",
+    "lint": "oxlint src",
+    "format": "oxfmt --write src",
+    "format:check": "oxfmt --check src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@studiometa/forge-api": "*",
+    "@studiometa/forge-core": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@vitest/coverage-v8": "^4.1.0-beta.4",
+    "typescript": "^5.7.3",
+    "vite": "^8.0.0-beta.14",
+    "vitest": "^4.1.0-beta.4"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+
+import { handleCertificatesCommand, showCertificatesHelp } from "./commands/certificates/index.ts";
+import { handleConfigCommand, showConfigHelp } from "./commands/config.ts";
+import { handleDaemonsCommand, showDaemonsHelp } from "./commands/daemons/index.ts";
+import { handleDatabasesCommand, showDatabasesHelp } from "./commands/databases/index.ts";
+import { handleDeploymentsCommand, showDeploymentsHelp } from "./commands/deployments/index.ts";
+import { handleEnvCommand, showEnvHelp } from "./commands/env/index.ts";
+import {
+  handleFirewallRulesCommand,
+  showFirewallRulesHelp,
+} from "./commands/firewall-rules/index.ts";
+import { handleNginxCommand, showNginxHelp } from "./commands/nginx/index.ts";
+import { handleRecipesCommand, showRecipesHelp } from "./commands/recipes/index.ts";
+import { handleServersCommand, showServersHelp } from "./commands/servers/index.ts";
+import { handleSitesCommand, showSitesHelp } from "./commands/sites/index.ts";
+import { handleSshKeysCommand, showSshKeysHelp } from "./commands/ssh-keys/index.ts";
+import { colors, setColorEnabled } from "./utils/colors.ts";
+import { parseArgs } from "./utils/args.ts";
+
+declare const __VERSION__: string;
+const VERSION = __VERSION__;
+
+function showHelp(): void {
+  console.log(`
+${colors.bold("forge-cli")} v${VERSION}
+
+${colors.bold("USAGE:")}
+  forge-cli <command> [subcommand] [options]
+
+${colors.bold("COMMANDS:")}
+  config              Manage CLI configuration
+    set <token>         Save API token
+    get                 Show current token (masked)
+    delete              Delete stored token
+
+  servers, s          Manage servers
+    list, ls            List all servers
+    get <id>            Get server details
+    reboot <id>         Reboot a server
+
+  sites               Manage sites
+    list, ls            List sites (requires --server)
+    get <id>            Get site details (requires --server)
+
+  deployments, d      Manage deployments
+    list, ls            List deployments (requires --server --site)
+    deploy              Trigger a deployment (requires --server --site)
+
+  databases, db       Manage databases
+    list, ls            List databases (requires --server)
+    get <id>            Get database details (requires --server)
+
+  daemons             Manage daemons
+    list, ls            List daemons (requires --server)
+    get <id>            Get daemon details (requires --server)
+    restart <id>        Restart a daemon (requires --server)
+
+  env                 Manage environment variables
+    get                 Get env variables (requires --server --site)
+    update              Update env variables (requires --server --site --content)
+
+  nginx               Manage nginx configuration
+    get                 Get nginx config (requires --server --site)
+    update              Update nginx config (requires --server --site --content)
+
+  certificates, certs Manage SSL certificates
+    list, ls            List certificates (requires --server --site)
+    get <id>            Get certificate details (requires --server --site)
+    activate <id>       Activate a certificate (requires --server --site)
+
+  firewall-rules, fw  Manage firewall rules
+    list, ls            List firewall rules (requires --server)
+    get <id>            Get firewall rule details (requires --server)
+
+  ssh-keys            Manage SSH keys
+    list, ls            List SSH keys (requires --server)
+    get <id>            Get SSH key details (requires --server)
+
+  recipes             Manage recipes
+    list, ls            List all recipes
+    get <id>            Get recipe details
+    run <id>            Run a recipe (requires --servers)
+
+${colors.bold("OPTIONS:")}
+  --token <token>     Forge API token (overrides config and env)
+  --server <id>       Server ID (required for server-scoped commands)
+  --site <id>         Site ID (required for site-scoped commands)
+  -f, --format <fmt>  Output format: json, human, table (default: human)
+  --no-color          Disable colored output
+  -h, --help          Show help
+  -v, --version       Show version
+
+${colors.bold("EXAMPLES:")}
+  # Configure API token
+  forge-cli config set YOUR_TOKEN
+
+  # Or pass token directly
+  forge-cli servers list --token YOUR_TOKEN
+
+  # List all servers
+  forge-cli servers list
+
+  # List sites on a server
+  forge-cli sites list --server 123
+
+  # Deploy a site
+  forge-cli deployments deploy --server 123 --site 456
+
+  # Get JSON output (for AI agents)
+  forge-cli servers list --format json
+
+${colors.bold("CREDENTIAL PRIORITY:")}
+  1. CLI argument (--token)
+  2. Environment variable (FORGE_API_TOKEN)
+  3. Config file (~/.config/forge-tools/config.json)
+
+${colors.bold("ENVIRONMENT VARIABLES:")}
+  FORGE_API_TOKEN    API token
+  NO_COLOR           Disable colors
+  XDG_CONFIG_HOME    Config directory (respects XDG spec)
+`);
+}
+
+async function main(): Promise<void> {
+  const { command, options, positional } = parseArgs();
+
+  const [mainCommand, subcommand] = command;
+  const wantsHelp = options.help !== undefined || options.h !== undefined;
+
+  if (wantsHelp && !mainCommand) {
+    showHelp();
+    process.exit(0);
+  }
+
+  if (options.version || options.v) {
+    console.log(VERSION);
+    process.exit(0);
+  }
+
+  if (options["no-color"]) {
+    setColorEnabled(false);
+  }
+
+  if (!mainCommand) {
+    showHelp();
+    process.exit(0);
+  }
+
+  try {
+    switch (mainCommand) {
+      case "config":
+        if (wantsHelp) {
+          showConfigHelp();
+          process.exit(0);
+        }
+        handleConfigCommand(
+          subcommand ?? "get",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "servers":
+      case "s":
+        if (wantsHelp) {
+          showServersHelp(subcommand);
+          process.exit(0);
+        }
+        await handleServersCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "sites":
+        if (wantsHelp) {
+          showSitesHelp(subcommand);
+          process.exit(0);
+        }
+        await handleSitesCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "deployments":
+      case "d":
+        if (wantsHelp) {
+          showDeploymentsHelp(subcommand);
+          process.exit(0);
+        }
+        await handleDeploymentsCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "databases":
+      case "db":
+        if (wantsHelp) {
+          showDatabasesHelp(subcommand);
+          process.exit(0);
+        }
+        await handleDatabasesCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "daemons":
+        if (wantsHelp) {
+          showDaemonsHelp(subcommand);
+          process.exit(0);
+        }
+        await handleDaemonsCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "env":
+        if (wantsHelp) {
+          showEnvHelp(subcommand);
+          process.exit(0);
+        }
+        await handleEnvCommand(
+          subcommand ?? "get",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "nginx":
+        if (wantsHelp) {
+          showNginxHelp(subcommand);
+          process.exit(0);
+        }
+        await handleNginxCommand(
+          subcommand ?? "get",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "certificates":
+      case "certs":
+        if (wantsHelp) {
+          showCertificatesHelp(subcommand);
+          process.exit(0);
+        }
+        await handleCertificatesCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "firewall-rules":
+      case "fw":
+        if (wantsHelp) {
+          showFirewallRulesHelp(subcommand);
+          process.exit(0);
+        }
+        await handleFirewallRulesCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "ssh-keys":
+        if (wantsHelp) {
+          showSshKeysHelp(subcommand);
+          process.exit(0);
+        }
+        await handleSshKeysCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      case "recipes":
+        if (wantsHelp) {
+          showRecipesHelp(subcommand);
+          process.exit(0);
+        }
+        await handleRecipesCommand(
+          subcommand ?? "list",
+          positional,
+          options as Record<string, string | boolean | string[]>,
+        );
+        break;
+
+      default:
+        console.error(colors.red(`Unknown command: ${mainCommand}`));
+        console.log(`Run ${colors.cyan("forge-cli --help")} for usage information`);
+        process.exit(1);
+    }
+  } catch (error) {
+    console.error(colors.red("Fatal error:"), error);
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(colors.red("Unhandled error:"), error);
+  process.exit(1);
+});

--- a/packages/cli/src/commands/certificates/command.test.ts
+++ b/packages/cli/src/commands/certificates/command.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleCertificatesCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  certificatesList: vi.fn().mockResolvedValue(undefined),
+  certificatesGet: vi.fn().mockResolvedValue(undefined),
+  certificatesActivate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleCertificatesCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list", async () => {
+    const h = await import("./handlers.ts");
+    await handleCertificatesCommand("list", [], {});
+    expect(h.certificatesList).toHaveBeenCalled();
+  });
+
+  it("should route activate with args", async () => {
+    const h = await import("./handlers.ts");
+    await handleCertificatesCommand("activate", ["1"], {});
+    expect(h.certificatesActivate).toHaveBeenCalledWith(["1"], expect.anything());
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleCertificatesCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/certificates/command.ts
+++ b/packages/cli/src/commands/certificates/command.ts
@@ -1,0 +1,12 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { certificatesList, certificatesGet, certificatesActivate } from "./handlers.ts";
+
+export const handleCertificatesCommand = createCommandRouter({
+  resource: "certificates",
+  handlers: {
+    list: certificatesList,
+    ls: certificatesList,
+    get: [certificatesGet, "args"],
+    activate: [certificatesActivate, "args"],
+  },
+});

--- a/packages/cli/src/commands/certificates/handlers.test.ts
+++ b/packages/cli/src/commands/certificates/handlers.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeCertificate } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { certificatesList, certificatesGet, certificatesActivate } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listCertificates: vi.fn(),
+  getCertificate: vi.fn(),
+  activateCertificate: vi.fn(),
+}));
+
+const mockCert: ForgeCertificate = {
+  id: 1,
+  server_id: 10,
+  site_id: 100,
+  domain: "example.com",
+  request_status: "complete",
+  status: "installed",
+  type: "letsencrypt",
+  created_at: "2024-01-01T00:00:00Z",
+  existing: false,
+  active: true,
+};
+
+describe("certificatesList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list certificates", async () => {
+    const { listCertificates } = await import("@studiometa/forge-core");
+    vi.mocked(listCertificates).mockResolvedValue({ data: [mockCert] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await certificatesList(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"example.com"'));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", site: "100" },
+    });
+
+    await certificatesList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no site_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await certificatesList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("certificatesGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get certificate", async () => {
+    const { getCertificate } = await import("@studiometa/forge-core");
+    vi.mocked(getCertificate).mockResolvedValue({ data: mockCert });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await certificatesGet(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"example.com"'));
+  });
+
+  it("should exit with error when no certificate_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await certificatesGet([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", site: "100" },
+    });
+
+    await certificatesGet(["1"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("certificatesActivate", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should activate certificate", async () => {
+    const { activateCertificate } = await import("@studiometa/forge-core");
+    vi.mocked(activateCertificate).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human", server: "10", site: "100" },
+    });
+
+    await certificatesActivate(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("activated"));
+  });
+
+  it("should exit with error when no certificate_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await certificatesActivate([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/certificates/handlers.ts
+++ b/packages/cli/src/commands/certificates/handlers.ts
@@ -1,0 +1,70 @@
+import { listCertificates, getCertificate, activateCertificate } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+function requireServerAndSite(
+  ctx: CommandContext,
+  usage: string,
+): { server_id: string; site_id: string } {
+  const server_id = String(ctx.options.server ?? "");
+  const site_id = String(ctx.options.site ?? "");
+
+  if (!server_id) {
+    exitWithValidationError("server_id", usage, ctx.formatter);
+  }
+  if (!site_id) {
+    exitWithValidationError("site_id", usage, ctx.formatter);
+  }
+
+  return { server_id, site_id };
+}
+
+export async function certificatesList(ctx: CommandContext): Promise<void> {
+  const usage = "forge-cli certificates list --server <server_id> --site <site_id>";
+  const { server_id, site_id } = requireServerAndSite(ctx, usage);
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listCertificates({ server_id, site_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function certificatesGet(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+  const usage = "forge-cli certificates get <cert_id> --server <server_id> --site <site_id>";
+
+  if (!id) {
+    exitWithValidationError("certificate_id", usage, ctx.formatter);
+  }
+
+  const { server_id, site_id } = requireServerAndSite(ctx, usage);
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getCertificate({ server_id, site_id, id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function certificatesActivate(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+  const usage = "forge-cli certificates activate <cert_id> --server <server_id> --site <site_id>";
+
+  if (!id) {
+    exitWithValidationError("certificate_id", usage, ctx.formatter);
+  }
+
+  const { server_id, site_id } = requireServerAndSite(ctx, usage);
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    await activateCertificate({ server_id, site_id, id }, execCtx);
+    ctx.formatter.success(`Certificate ${id} activated.`);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/certificates/help.test.ts
+++ b/packages/cli/src/commands/certificates/help.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showCertificatesHelp } from "./help.ts";
+
+describe("showCertificatesHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showCertificatesHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("certificates"));
+  });
+
+  it("should show list help", () => {
+    showCertificatesHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("certificates list"));
+  });
+
+  it("should show list help for ls", () => {
+    showCertificatesHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("certificates list"));
+  });
+
+  it("should show get help", () => {
+    showCertificatesHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("cert_id"));
+  });
+
+  it("should show activate help", () => {
+    showCertificatesHelp("activate");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("activate"));
+  });
+});

--- a/packages/cli/src/commands/certificates/help.ts
+++ b/packages/cli/src/commands/certificates/help.ts
@@ -1,0 +1,48 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showCertificatesHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli certificates list")} - List certificates for a site
+
+${colors.bold("USAGE:")}
+  forge-cli certificates list --server <server_id> --site <site_id> [options]
+`);
+  } else if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli certificates get")} - Get certificate details
+
+${colors.bold("USAGE:")}
+  forge-cli certificates get <cert_id> --server <server_id> --site <site_id>
+`);
+  } else if (subcommand === "activate") {
+    console.log(`
+${colors.bold("forge-cli certificates activate")} - Activate a certificate
+
+${colors.bold("USAGE:")}
+  forge-cli certificates activate <cert_id> --server <server_id> --site <site_id>
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli certificates")} - Manage SSL certificates
+
+${colors.bold("USAGE:")}
+  forge-cli certificates <subcommand> [options]
+
+${colors.bold("ALIASES:")}
+  forge-cli certs
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List certificates
+  get <id>            Get certificate details
+  activate <id>       Activate a certificate
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  --site <id>         Site ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+
+Run ${colors.cyan("forge-cli certificates <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/certificates/index.ts
+++ b/packages/cli/src/commands/certificates/index.ts
@@ -1,0 +1,2 @@
+export { handleCertificatesCommand } from "./command.ts";
+export { showCertificatesHelp } from "./help.ts";

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleConfigCommand, showConfigHelp } from "./config.ts";
+
+vi.mock("../config.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config.ts")>();
+  return {
+    ...actual,
+    createConfigStore: vi.fn().mockReturnValue({}),
+    getToken: vi.fn().mockReturnValue(null),
+    setToken: vi.fn(),
+    deleteToken: vi.fn(),
+  };
+});
+
+describe("showConfigHelp", () => {
+  it("should print help text", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    showConfigHelp();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("forge-cli config"));
+    spy.mockRestore();
+  });
+});
+
+describe("handleConfigCommand", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("set subcommand", () => {
+    it("should save token", async () => {
+      const { setToken } = await import("../config.ts");
+
+      handleConfigCommand("set", ["my-token"], { format: "json" });
+
+      expect(setToken).toHaveBeenCalledWith("my-token", expect.anything());
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("success"));
+    });
+
+    it("should exit with error when no token", () => {
+      handleConfigCommand("set", [], { format: "json" });
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("get subcommand", () => {
+    it("should show warning when no token configured", async () => {
+      const { getToken } = await import("../config.ts");
+      vi.mocked(getToken).mockReturnValue(null);
+
+      handleConfigCommand("get", [], { format: "human" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("⚠"));
+    });
+
+    it("should show masked token in human format", async () => {
+      const { getToken } = await import("../config.ts");
+      vi.mocked(getToken).mockReturnValue("abcd1234efgh5678");
+
+      handleConfigCommand("get", [], { format: "human" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("abcd"));
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("5678"));
+    });
+
+    it("should show masked token in json format", async () => {
+      const { getToken } = await import("../config.ts");
+      vi.mocked(getToken).mockReturnValue("abcd1234efgh5678");
+
+      handleConfigCommand("get", [], { format: "json" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("apiToken"));
+    });
+
+    it("should handle short token masking", async () => {
+      const { getToken } = await import("../config.ts");
+      vi.mocked(getToken).mockReturnValue("short");
+
+      handleConfigCommand("get", [], { format: "human" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("****"));
+    });
+  });
+
+  describe("delete subcommand", () => {
+    it("should delete token", async () => {
+      const { deleteToken } = await import("../config.ts");
+
+      handleConfigCommand("delete", [], { format: "json" });
+
+      expect(deleteToken).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("success"));
+    });
+  });
+
+  describe("unknown subcommand", () => {
+    it("should show help for unknown subcommand", () => {
+      handleConfigCommand("unknown", [], {});
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("forge-cli config"));
+    });
+  });
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,84 @@
+/**
+ * Config command — manage forge-cli configuration
+ */
+
+import { createConfigStore, setToken, deleteToken, getToken } from "../config.ts";
+import { OutputFormatter } from "../output.ts";
+import { colors } from "../utils/colors.ts";
+
+export function showConfigHelp(): void {
+  console.log(`
+${colors.bold("forge-cli config")} - Manage CLI configuration
+
+${colors.bold("USAGE:")}
+  forge-cli config <subcommand> [options]
+
+${colors.bold("SUBCOMMANDS:")}
+  set <token>         Save API token to config file
+  get                 Show current API token (masked)
+  delete              Delete stored API token
+
+${colors.bold("EXAMPLES:")}
+  forge-cli config set YOUR_FORGE_TOKEN
+  forge-cli config get
+  forge-cli config delete
+`);
+}
+
+export function handleConfigCommand(
+  subcommand: string,
+  args: string[],
+  options: Record<string, string | boolean | string[]>,
+): void {
+  const format = String(options.format ?? options.f ?? "human");
+  const formatter = new OutputFormatter(
+    format as "json" | "human" | "table",
+    options["no-color"] === true,
+  );
+
+  const store = createConfigStore();
+
+  switch (subcommand) {
+    case "set": {
+      const [token] = args;
+      if (!token) {
+        formatter.error("Token is required. Usage: forge-cli config set <token>");
+        process.exit(1);
+        return;
+      }
+      setToken(token, store);
+      formatter.success("API token saved.");
+      break;
+    }
+
+    case "get": {
+      const token = getToken(store);
+      if (!token) {
+        formatter.warning("No API token configured.");
+        formatter.info("Run: forge-cli config set <token>");
+      } else {
+        // Mask the token for security
+        const masked =
+          token.length > 8
+            ? `${token.slice(0, 4)}${"*".repeat(token.length - 8)}${token.slice(-4)}`
+            : "****";
+        if (format === "json") {
+          formatter.output({ apiToken: masked });
+        } else {
+          console.log(`apiToken: ${masked}`);
+        }
+      }
+      break;
+    }
+
+    case "delete": {
+      deleteToken(store);
+      formatter.success("API token deleted.");
+      break;
+    }
+
+    default:
+      showConfigHelp();
+      break;
+  }
+}

--- a/packages/cli/src/commands/daemons/command.test.ts
+++ b/packages/cli/src/commands/daemons/command.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleDaemonsCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  daemonsList: vi.fn().mockResolvedValue(undefined),
+  daemonsGet: vi.fn().mockResolvedValue(undefined),
+  daemonsRestart: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleDaemonsCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list", async () => {
+    const h = await import("./handlers.ts");
+    await handleDaemonsCommand("list", [], {});
+    expect(h.daemonsList).toHaveBeenCalled();
+  });
+
+  it("should route restart with args", async () => {
+    const h = await import("./handlers.ts");
+    await handleDaemonsCommand("restart", ["1"], {});
+    expect(h.daemonsRestart).toHaveBeenCalledWith(["1"], expect.anything());
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleDaemonsCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/daemons/command.ts
+++ b/packages/cli/src/commands/daemons/command.ts
@@ -1,0 +1,12 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { daemonsList, daemonsGet, daemonsRestart } from "./handlers.ts";
+
+export const handleDaemonsCommand = createCommandRouter({
+  resource: "daemons",
+  handlers: {
+    list: daemonsList,
+    ls: daemonsList,
+    get: [daemonsGet, "args"],
+    restart: [daemonsRestart, "args"],
+  },
+});

--- a/packages/cli/src/commands/daemons/handlers.test.ts
+++ b/packages/cli/src/commands/daemons/handlers.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeDaemon } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { daemonsList, daemonsGet, daemonsRestart } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listDaemons: vi.fn(),
+  getDaemon: vi.fn(),
+  restartDaemon: vi.fn(),
+}));
+
+const mockDaemon: ForgeDaemon = {
+  id: 1,
+  server_id: 10,
+  command: "php artisan queue:work",
+  user: "forge",
+  directory: null,
+  processes: 1,
+  startsecs: 1,
+  stopsignal: "TERM",
+  stopwaitsecs: 10,
+  status: "running",
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+describe("daemonsList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list daemons", async () => {
+    const { listDaemons } = await import("@studiometa/forge-core");
+    vi.mocked(listDaemons).mockResolvedValue({ data: [mockDaemon] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await daemonsList(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"running"'));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await daemonsList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("daemonsGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get daemon by id", async () => {
+    const { getDaemon } = await import("@studiometa/forge-core");
+    vi.mocked(getDaemon).mockResolvedValue({ data: mockDaemon });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await daemonsGet(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"running"'));
+  });
+
+  it("should exit with error when no daemon_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await daemonsGet([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await daemonsGet(["1"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("daemonsRestart", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should restart daemon", async () => {
+    const { restartDaemon } = await import("@studiometa/forge-core");
+    vi.mocked(restartDaemon).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human", server: "10" },
+    });
+
+    await daemonsRestart(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("restarted"));
+  });
+
+  it("should exit with error when no daemon_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await daemonsRestart([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await daemonsRestart(["1"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/daemons/handlers.ts
+++ b/packages/cli/src/commands/daemons/handlers.ts
@@ -1,0 +1,80 @@
+import { listDaemons, getDaemon, restartDaemon } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function daemonsList(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli daemons list --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listDaemons({ server_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function daemonsGet(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!id) {
+    exitWithValidationError(
+      "daemon_id",
+      "forge-cli daemons get <daemon_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli daemons get <daemon_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getDaemon({ server_id, id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function daemonsRestart(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!id) {
+    exitWithValidationError(
+      "daemon_id",
+      "forge-cli daemons restart <daemon_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli daemons restart <daemon_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    await restartDaemon({ server_id, id }, execCtx);
+    ctx.formatter.success(`Daemon ${id} restarted.`);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/daemons/help.test.ts
+++ b/packages/cli/src/commands/daemons/help.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showDaemonsHelp } from "./help.ts";
+
+describe("showDaemonsHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showDaemonsHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("daemons"));
+  });
+
+  it("should show list help", () => {
+    showDaemonsHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("daemons list"));
+  });
+
+  it("should show list help for ls", () => {
+    showDaemonsHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("daemons list"));
+  });
+
+  it("should show get help", () => {
+    showDaemonsHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("daemon_id"));
+  });
+
+  it("should show restart help", () => {
+    showDaemonsHelp("restart");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("restart"));
+  });
+});

--- a/packages/cli/src/commands/daemons/help.ts
+++ b/packages/cli/src/commands/daemons/help.ts
@@ -1,0 +1,44 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showDaemonsHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli daemons list")} - List daemons on a server
+
+${colors.bold("USAGE:")}
+  forge-cli daemons list --server <server_id> [options]
+`);
+  } else if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli daemons get")} - Get daemon details
+
+${colors.bold("USAGE:")}
+  forge-cli daemons get <daemon_id> --server <server_id>
+`);
+  } else if (subcommand === "restart") {
+    console.log(`
+${colors.bold("forge-cli daemons restart")} - Restart a daemon
+
+${colors.bold("USAGE:")}
+  forge-cli daemons restart <daemon_id> --server <server_id>
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli daemons")} - Manage daemons
+
+${colors.bold("USAGE:")}
+  forge-cli daemons <subcommand> [options]
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List daemons
+  get <id>            Get daemon details
+  restart <id>        Restart a daemon
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+
+Run ${colors.cyan("forge-cli daemons <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/daemons/index.ts
+++ b/packages/cli/src/commands/daemons/index.ts
@@ -1,0 +1,2 @@
+export { handleDaemonsCommand } from "./command.ts";
+export { showDaemonsHelp } from "./help.ts";

--- a/packages/cli/src/commands/databases/command.test.ts
+++ b/packages/cli/src/commands/databases/command.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleDatabasesCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  databasesList: vi.fn().mockResolvedValue(undefined),
+  databasesGet: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleDatabasesCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list", async () => {
+    const h = await import("./handlers.ts");
+    await handleDatabasesCommand("list", [], {});
+    expect(h.databasesList).toHaveBeenCalled();
+  });
+
+  it("should route get with args", async () => {
+    const h = await import("./handlers.ts");
+    await handleDatabasesCommand("get", ["1"], {});
+    expect(h.databasesGet).toHaveBeenCalledWith(["1"], expect.anything());
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleDatabasesCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/databases/command.ts
+++ b/packages/cli/src/commands/databases/command.ts
@@ -1,0 +1,11 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { databasesList, databasesGet } from "./handlers.ts";
+
+export const handleDatabasesCommand = createCommandRouter({
+  resource: "databases",
+  handlers: {
+    list: databasesList,
+    ls: databasesList,
+    get: [databasesGet, "args"],
+  },
+});

--- a/packages/cli/src/commands/databases/handlers.test.ts
+++ b/packages/cli/src/commands/databases/handlers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeDatabase } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { databasesList, databasesGet } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listDatabases: vi.fn(),
+  getDatabase: vi.fn(),
+}));
+
+const mockDb: ForgeDatabase = {
+  id: 1,
+  server_id: 10,
+  name: "mydb",
+  status: "installed",
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+describe("databasesList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list databases", async () => {
+    const { listDatabases } = await import("@studiometa/forge-core");
+    vi.mocked(listDatabases).mockResolvedValue({ data: [mockDb] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await databasesList(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"mydb"'));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await databasesList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("databasesGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get database by id", async () => {
+    const { getDatabase } = await import("@studiometa/forge-core");
+    vi.mocked(getDatabase).mockResolvedValue({ data: mockDb });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await databasesGet(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"mydb"'));
+  });
+
+  it("should exit with error when no database_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await databasesGet([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await databasesGet(["1"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/databases/handlers.ts
+++ b/packages/cli/src/commands/databases/handlers.ts
@@ -1,0 +1,52 @@
+import { listDatabases, getDatabase } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function databasesList(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli databases list --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listDatabases({ server_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function databasesGet(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!id) {
+    exitWithValidationError(
+      "database_id",
+      "forge-cli databases get <database_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli databases get <database_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getDatabase({ server_id, id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/databases/help.test.ts
+++ b/packages/cli/src/commands/databases/help.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showDatabasesHelp } from "./help.ts";
+
+describe("showDatabasesHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showDatabasesHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("databases"));
+  });
+
+  it("should show list help", () => {
+    showDatabasesHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("databases list"));
+  });
+
+  it("should show list help for ls", () => {
+    showDatabasesHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("databases list"));
+  });
+
+  it("should show get help", () => {
+    showDatabasesHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("database_id"));
+  });
+});

--- a/packages/cli/src/commands/databases/help.ts
+++ b/packages/cli/src/commands/databases/help.ts
@@ -1,0 +1,43 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showDatabasesHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli databases list")} - List databases on a server
+
+${colors.bold("USAGE:")}
+  forge-cli databases list --server <server_id> [options]
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+`);
+  } else if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli databases get")} - Get database details
+
+${colors.bold("USAGE:")}
+  forge-cli databases get <database_id> --server <server_id> [options]
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli databases")} - Manage databases
+
+${colors.bold("USAGE:")}
+  forge-cli databases <subcommand> [options]
+
+${colors.bold("ALIASES:")}
+  forge-cli db
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List databases
+  get <id>            Get database details
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+
+Run ${colors.cyan("forge-cli databases <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/databases/index.ts
+++ b/packages/cli/src/commands/databases/index.ts
@@ -1,0 +1,2 @@
+export { handleDatabasesCommand } from "./command.ts";
+export { showDatabasesHelp } from "./help.ts";

--- a/packages/cli/src/commands/deployments/command.test.ts
+++ b/packages/cli/src/commands/deployments/command.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleDeploymentsCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  deploymentsList: vi.fn().mockResolvedValue(undefined),
+  deploymentsDeploy: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: { format: "json" },
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleDeploymentsCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const handlers = await import("./handlers.ts");
+    vi.mocked(handlers.deploymentsList).mockClear();
+    vi.mocked(handlers.deploymentsDeploy).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list subcommand", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleDeploymentsCommand("list", [], {});
+    expect(handlers.deploymentsList).toHaveBeenCalled();
+  });
+
+  it("should route deploy subcommand", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleDeploymentsCommand("deploy", [], {});
+    expect(handlers.deploymentsDeploy).toHaveBeenCalled();
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleDeploymentsCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/deployments/command.ts
+++ b/packages/cli/src/commands/deployments/command.ts
@@ -1,0 +1,11 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { deploymentsList, deploymentsDeploy } from "./handlers.ts";
+
+export const handleDeploymentsCommand = createCommandRouter({
+  resource: "deployments",
+  handlers: {
+    list: deploymentsList,
+    ls: deploymentsList,
+    deploy: deploymentsDeploy,
+  },
+});

--- a/packages/cli/src/commands/deployments/handlers.test.ts
+++ b/packages/cli/src/commands/deployments/handlers.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeDeployment } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { deploymentsList, deploymentsDeploy } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listDeployments: vi.fn(),
+  deploySite: vi.fn(),
+}));
+
+const mockDeployment: ForgeDeployment = {
+  id: 1,
+  server_id: 10,
+  site_id: 100,
+  type: 1,
+  commit_hash: "abc123",
+  commit_author: "John",
+  commit_message: "Deploy",
+  started_at: "2024-01-01T00:00:00Z",
+  ended_at: "2024-01-01T00:01:00Z",
+  status: "finished",
+  displayable_type: "push",
+};
+
+describe("deploymentsList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list deployments", async () => {
+    const { listDeployments } = await import("@studiometa/forge-core");
+    vi.mocked(listDeployments).mockResolvedValue({ data: [mockDeployment] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await deploymentsList(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"finished"'));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", site: "100" },
+    });
+
+    await deploymentsList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no site_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await deploymentsList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("deploymentsDeploy", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should trigger deployment", async () => {
+    const { deploySite } = await import("@studiometa/forge-core");
+    vi.mocked(deploySite).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human", server: "10", site: "100" },
+    });
+
+    await deploymentsDeploy(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(
+      expect.stringContaining("Deployment triggered"),
+    );
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", site: "100" },
+    });
+
+    await deploymentsDeploy(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no site_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await deploymentsDeploy(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/deployments/handlers.ts
+++ b/packages/cli/src/commands/deployments/handlers.ts
@@ -1,0 +1,61 @@
+import { listDeployments, deploySite } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function deploymentsList(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+  const site_id = String(ctx.options.site ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli deployments list --server <server_id> --site <site_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!site_id) {
+    exitWithValidationError(
+      "site_id",
+      "forge-cli deployments list --server <server_id> --site <site_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listDeployments({ server_id, site_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function deploymentsDeploy(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+  const site_id = String(ctx.options.site ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli deployments deploy --server <server_id> --site <site_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!site_id) {
+    exitWithValidationError(
+      "site_id",
+      "forge-cli deployments deploy --server <server_id> --site <site_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    await deploySite({ server_id, site_id }, execCtx);
+    ctx.formatter.success(`Deployment triggered for site ${site_id}.`);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/deployments/help.test.ts
+++ b/packages/cli/src/commands/deployments/help.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showDeploymentsHelp } from "./help.ts";
+
+describe("showDeploymentsHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showDeploymentsHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("deployments"));
+  });
+
+  it("should show list help", () => {
+    showDeploymentsHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("deployments list"));
+  });
+
+  it("should show list help for ls", () => {
+    showDeploymentsHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("deployments list"));
+  });
+
+  it("should show deploy help", () => {
+    showDeploymentsHelp("deploy");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("deploy"));
+  });
+});

--- a/packages/cli/src/commands/deployments/help.ts
+++ b/packages/cli/src/commands/deployments/help.ts
@@ -1,0 +1,45 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showDeploymentsHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli deployments list")} - List deployments for a site
+
+${colors.bold("USAGE:")}
+  forge-cli deployments list --server <server_id> --site <site_id> [options]
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  --site <id>         Site ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+`);
+  } else if (subcommand === "deploy") {
+    console.log(`
+${colors.bold("forge-cli deployments deploy")} - Trigger a deployment
+
+${colors.bold("USAGE:")}
+  forge-cli deployments deploy --server <server_id> --site <site_id>
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli deployments")} - Manage deployments
+
+${colors.bold("USAGE:")}
+  forge-cli deployments <subcommand> [options]
+
+${colors.bold("ALIASES:")}
+  forge-cli d
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List deployments for a site
+  deploy              Trigger a deployment
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  --site <id>         Site ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+
+Run ${colors.cyan("forge-cli deployments <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/deployments/index.ts
+++ b/packages/cli/src/commands/deployments/index.ts
@@ -1,0 +1,2 @@
+export { handleDeploymentsCommand } from "./command.ts";
+export { showDeploymentsHelp } from "./help.ts";

--- a/packages/cli/src/commands/env/command.test.ts
+++ b/packages/cli/src/commands/env/command.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleEnvCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  envGet: vi.fn().mockResolvedValue(undefined),
+  envUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleEnvCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route get", async () => {
+    const h = await import("./handlers.ts");
+    await handleEnvCommand("get", [], {});
+    expect(h.envGet).toHaveBeenCalled();
+  });
+
+  it("should route update", async () => {
+    const h = await import("./handlers.ts");
+    await handleEnvCommand("update", [], {});
+    expect(h.envUpdate).toHaveBeenCalled();
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleEnvCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -1,0 +1,10 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { envGet, envUpdate } from "./handlers.ts";
+
+export const handleEnvCommand = createCommandRouter({
+  resource: "env",
+  handlers: {
+    get: envGet,
+    update: envUpdate,
+  },
+});

--- a/packages/cli/src/commands/env/handlers.test.ts
+++ b/packages/cli/src/commands/env/handlers.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createTestContext } from "../../context.ts";
+import { envGet, envUpdate } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  getEnv: vi.fn(),
+  updateEnv: vi.fn(),
+}));
+
+describe("envGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get env", async () => {
+    const { getEnv } = await import("@studiometa/forge-core");
+    vi.mocked(getEnv).mockResolvedValue({ data: "APP_ENV=production" });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await envGet(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("APP_ENV"));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", site: "100" },
+    });
+
+    await envGet(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no site_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await envGet(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("envUpdate", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should update env", async () => {
+    const { updateEnv } = await import("@studiometa/forge-core");
+    vi.mocked(updateEnv).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human", server: "10", site: "100", content: "APP_ENV=prod" },
+    });
+
+    await envUpdate(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("updated"));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", site: "100", content: "X=1" },
+    });
+
+    await envUpdate(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no site_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", content: "X=1" },
+    });
+
+    await envUpdate(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no content", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await envUpdate(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/env/handlers.ts
+++ b/packages/cli/src/commands/env/handlers.ts
@@ -1,0 +1,70 @@
+import { getEnv, updateEnv } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function envGet(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+  const site_id = String(ctx.options.site ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli env get --server <server_id> --site <site_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!site_id) {
+    exitWithValidationError(
+      "site_id",
+      "forge-cli env get --server <server_id> --site <site_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getEnv({ server_id, site_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function envUpdate(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+  const site_id = String(ctx.options.site ?? "");
+  const content = String(ctx.options.content ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli env update --server <server_id> --site <site_id> --content <content>",
+      ctx.formatter,
+    );
+  }
+
+  if (!site_id) {
+    exitWithValidationError(
+      "site_id",
+      "forge-cli env update --server <server_id> --site <site_id> --content <content>",
+      ctx.formatter,
+    );
+  }
+
+  if (!content) {
+    exitWithValidationError(
+      "content",
+      "forge-cli env update --server <server_id> --site <site_id> --content <content>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    await updateEnv({ server_id, site_id, content }, execCtx);
+    ctx.formatter.success("Environment variables updated.");
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/env/help.test.ts
+++ b/packages/cli/src/commands/env/help.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showEnvHelp } from "./help.ts";
+
+describe("showEnvHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showEnvHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("env"));
+  });
+
+  it("should show get help", () => {
+    showEnvHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("env get"));
+  });
+
+  it("should show update help", () => {
+    showEnvHelp("update");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("env update"));
+  });
+});

--- a/packages/cli/src/commands/env/help.ts
+++ b/packages/cli/src/commands/env/help.ts
@@ -1,0 +1,38 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showEnvHelp(subcommand?: string): void {
+  if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli env get")} - Get environment variables
+
+${colors.bold("USAGE:")}
+  forge-cli env get --server <server_id> --site <site_id>
+`);
+  } else if (subcommand === "update") {
+    console.log(`
+${colors.bold("forge-cli env update")} - Update environment variables
+
+${colors.bold("USAGE:")}
+  forge-cli env update --server <server_id> --site <site_id> --content <env_content>
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli env")} - Manage environment variables
+
+${colors.bold("USAGE:")}
+  forge-cli env <subcommand> [options]
+
+${colors.bold("SUBCOMMANDS:")}
+  get                 Get environment variables
+  update              Update environment variables
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  --site <id>         Site ID (required)
+  --content <str>     New env content (for update)
+  -f, --format <fmt>  Output format: json, human
+
+Run ${colors.cyan("forge-cli env <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -1,0 +1,2 @@
+export { handleEnvCommand } from "./command.ts";
+export { showEnvHelp } from "./help.ts";

--- a/packages/cli/src/commands/firewall-rules/command.test.ts
+++ b/packages/cli/src/commands/firewall-rules/command.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleFirewallRulesCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  firewallRulesList: vi.fn().mockResolvedValue(undefined),
+  firewallRulesGet: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleFirewallRulesCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list", async () => {
+    const h = await import("./handlers.ts");
+    await handleFirewallRulesCommand("list", [], {});
+    expect(h.firewallRulesList).toHaveBeenCalled();
+  });
+
+  it("should route get with args", async () => {
+    const h = await import("./handlers.ts");
+    await handleFirewallRulesCommand("get", ["1"], {});
+    expect(h.firewallRulesGet).toHaveBeenCalledWith(["1"], expect.anything());
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleFirewallRulesCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/firewall-rules/command.ts
+++ b/packages/cli/src/commands/firewall-rules/command.ts
@@ -1,0 +1,11 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { firewallRulesList, firewallRulesGet } from "./handlers.ts";
+
+export const handleFirewallRulesCommand = createCommandRouter({
+  resource: "firewall-rules",
+  handlers: {
+    list: firewallRulesList,
+    ls: firewallRulesList,
+    get: [firewallRulesGet, "args"],
+  },
+});

--- a/packages/cli/src/commands/firewall-rules/handlers.test.ts
+++ b/packages/cli/src/commands/firewall-rules/handlers.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeFirewallRule } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { firewallRulesList, firewallRulesGet } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listFirewallRules: vi.fn(),
+  getFirewallRule: vi.fn(),
+}));
+
+const mockRule: ForgeFirewallRule = {
+  id: 1,
+  server_id: 10,
+  name: "Allow HTTP",
+  port: 80,
+  type: "allow",
+  ip_address: "0.0.0.0",
+  status: "installed",
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+describe("firewallRulesList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list firewall rules", async () => {
+    const { listFirewallRules } = await import("@studiometa/forge-core");
+    vi.mocked(listFirewallRules).mockResolvedValue({ data: [mockRule] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await firewallRulesList(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"Allow HTTP"'));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await firewallRulesList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("firewallRulesGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get firewall rule", async () => {
+    const { getFirewallRule } = await import("@studiometa/forge-core");
+    vi.mocked(getFirewallRule).mockResolvedValue({ data: mockRule });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await firewallRulesGet(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"Allow HTTP"'));
+  });
+
+  it("should exit with error when no rule id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await firewallRulesGet([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await firewallRulesGet(["1"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/firewall-rules/handlers.ts
+++ b/packages/cli/src/commands/firewall-rules/handlers.ts
@@ -1,0 +1,52 @@
+import { listFirewallRules, getFirewallRule } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function firewallRulesList(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli firewall-rules list --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listFirewallRules({ server_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function firewallRulesGet(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!id) {
+    exitWithValidationError(
+      "firewall_rule_id",
+      "forge-cli firewall-rules get <rule_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli firewall-rules get <rule_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getFirewallRule({ server_id, id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/firewall-rules/help.test.ts
+++ b/packages/cli/src/commands/firewall-rules/help.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showFirewallRulesHelp } from "./help.ts";
+
+describe("showFirewallRulesHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showFirewallRulesHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("firewall-rules"));
+  });
+
+  it("should show list help", () => {
+    showFirewallRulesHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("firewall-rules list"));
+  });
+
+  it("should show list help for ls", () => {
+    showFirewallRulesHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("firewall-rules list"));
+  });
+
+  it("should show get help", () => {
+    showFirewallRulesHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("rule_id"));
+  });
+});

--- a/packages/cli/src/commands/firewall-rules/help.ts
+++ b/packages/cli/src/commands/firewall-rules/help.ts
@@ -1,0 +1,39 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showFirewallRulesHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli firewall-rules list")} - List firewall rules on a server
+
+${colors.bold("USAGE:")}
+  forge-cli firewall-rules list --server <server_id> [options]
+`);
+  } else if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli firewall-rules get")} - Get firewall rule details
+
+${colors.bold("USAGE:")}
+  forge-cli firewall-rules get <rule_id> --server <server_id>
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli firewall-rules")} - Manage firewall rules
+
+${colors.bold("USAGE:")}
+  forge-cli firewall-rules <subcommand> [options]
+
+${colors.bold("ALIASES:")}
+  forge-cli fw
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List firewall rules
+  get <id>            Get firewall rule details
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+
+Run ${colors.cyan("forge-cli firewall-rules <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/firewall-rules/index.ts
+++ b/packages/cli/src/commands/firewall-rules/index.ts
@@ -1,0 +1,2 @@
+export { handleFirewallRulesCommand } from "./command.ts";
+export { showFirewallRulesHelp } from "./help.ts";

--- a/packages/cli/src/commands/nginx/command.test.ts
+++ b/packages/cli/src/commands/nginx/command.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleNginxCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  nginxGet: vi.fn().mockResolvedValue(undefined),
+  nginxUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleNginxCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route get", async () => {
+    const h = await import("./handlers.ts");
+    await handleNginxCommand("get", [], {});
+    expect(h.nginxGet).toHaveBeenCalled();
+  });
+
+  it("should route update", async () => {
+    const h = await import("./handlers.ts");
+    await handleNginxCommand("update", [], {});
+    expect(h.nginxUpdate).toHaveBeenCalled();
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleNginxCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/nginx/command.ts
+++ b/packages/cli/src/commands/nginx/command.ts
@@ -1,0 +1,10 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { nginxGet, nginxUpdate } from "./handlers.ts";
+
+export const handleNginxCommand = createCommandRouter({
+  resource: "nginx",
+  handlers: {
+    get: nginxGet,
+    update: nginxUpdate,
+  },
+});

--- a/packages/cli/src/commands/nginx/handlers.test.ts
+++ b/packages/cli/src/commands/nginx/handlers.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createTestContext } from "../../context.ts";
+import { nginxGet, nginxUpdate } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  getNginxConfig: vi.fn(),
+  updateNginxConfig: vi.fn(),
+}));
+
+describe("nginxGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get nginx config", async () => {
+    const { getNginxConfig } = await import("@studiometa/forge-core");
+    vi.mocked(getNginxConfig).mockResolvedValue({ data: "server { }" });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await nginxGet(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("server {"));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", site: "100" },
+    });
+
+    await nginxGet(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no site_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await nginxGet(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("nginxUpdate", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should update nginx config", async () => {
+    const { updateNginxConfig } = await import("@studiometa/forge-core");
+    vi.mocked(updateNginxConfig).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human", server: "10", site: "100", content: "server { }" },
+    });
+
+    await nginxUpdate(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("updated"));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", site: "100", content: "x" },
+    });
+
+    await nginxUpdate(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no site_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", content: "x" },
+    });
+
+    await nginxUpdate(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no content", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10", site: "100" },
+    });
+
+    await nginxUpdate(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/nginx/handlers.ts
+++ b/packages/cli/src/commands/nginx/handlers.ts
@@ -1,0 +1,70 @@
+import { getNginxConfig, updateNginxConfig } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function nginxGet(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+  const site_id = String(ctx.options.site ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli nginx get --server <server_id> --site <site_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!site_id) {
+    exitWithValidationError(
+      "site_id",
+      "forge-cli nginx get --server <server_id> --site <site_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getNginxConfig({ server_id, site_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function nginxUpdate(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+  const site_id = String(ctx.options.site ?? "");
+  const content = String(ctx.options.content ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli nginx update --server <server_id> --site <site_id> --content <content>",
+      ctx.formatter,
+    );
+  }
+
+  if (!site_id) {
+    exitWithValidationError(
+      "site_id",
+      "forge-cli nginx update --server <server_id> --site <site_id> --content <content>",
+      ctx.formatter,
+    );
+  }
+
+  if (!content) {
+    exitWithValidationError(
+      "content",
+      "forge-cli nginx update --server <server_id> --site <site_id> --content <content>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    await updateNginxConfig({ server_id, site_id, content }, execCtx);
+    ctx.formatter.success("Nginx configuration updated.");
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/nginx/help.test.ts
+++ b/packages/cli/src/commands/nginx/help.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showNginxHelp } from "./help.ts";
+
+describe("showNginxHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showNginxHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("nginx"));
+  });
+
+  it("should show get help", () => {
+    showNginxHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("nginx get"));
+  });
+
+  it("should show update help", () => {
+    showNginxHelp("update");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("nginx update"));
+  });
+});

--- a/packages/cli/src/commands/nginx/help.ts
+++ b/packages/cli/src/commands/nginx/help.ts
@@ -1,0 +1,37 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showNginxHelp(subcommand?: string): void {
+  if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli nginx get")} - Get nginx configuration
+
+${colors.bold("USAGE:")}
+  forge-cli nginx get --server <server_id> --site <site_id>
+`);
+  } else if (subcommand === "update") {
+    console.log(`
+${colors.bold("forge-cli nginx update")} - Update nginx configuration
+
+${colors.bold("USAGE:")}
+  forge-cli nginx update --server <server_id> --site <site_id> --content <nginx_config>
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli nginx")} - Manage nginx configuration
+
+${colors.bold("USAGE:")}
+  forge-cli nginx <subcommand> [options]
+
+${colors.bold("SUBCOMMANDS:")}
+  get                 Get nginx configuration
+  update              Update nginx configuration
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  --site <id>         Site ID (required)
+  --content <str>     New nginx config (for update)
+
+Run ${colors.cyan("forge-cli nginx <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/nginx/index.ts
+++ b/packages/cli/src/commands/nginx/index.ts
@@ -1,0 +1,2 @@
+export { handleNginxCommand } from "./command.ts";
+export { showNginxHelp } from "./help.ts";

--- a/packages/cli/src/commands/recipes/command.test.ts
+++ b/packages/cli/src/commands/recipes/command.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleRecipesCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  recipesList: vi.fn().mockResolvedValue(undefined),
+  recipesGet: vi.fn().mockResolvedValue(undefined),
+  recipesRun: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleRecipesCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list", async () => {
+    const h = await import("./handlers.ts");
+    await handleRecipesCommand("list", [], {});
+    expect(h.recipesList).toHaveBeenCalled();
+  });
+
+  it("should route run with args", async () => {
+    const h = await import("./handlers.ts");
+    await handleRecipesCommand("run", ["1"], {});
+    expect(h.recipesRun).toHaveBeenCalledWith(["1"], expect.anything());
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleRecipesCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/recipes/command.ts
+++ b/packages/cli/src/commands/recipes/command.ts
@@ -1,0 +1,12 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { recipesList, recipesGet, recipesRun } from "./handlers.ts";
+
+export const handleRecipesCommand = createCommandRouter({
+  resource: "recipes",
+  handlers: {
+    list: recipesList,
+    ls: recipesList,
+    get: [recipesGet, "args"],
+    run: [recipesRun, "args"],
+  },
+});

--- a/packages/cli/src/commands/recipes/handlers.test.ts
+++ b/packages/cli/src/commands/recipes/handlers.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeRecipe } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { recipesList, recipesGet, recipesRun } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listRecipes: vi.fn(),
+  getRecipe: vi.fn(),
+  runRecipe: vi.fn(),
+}));
+
+const mockRecipe: ForgeRecipe = {
+  id: 1,
+  name: "Deploy Script",
+  user: "forge",
+  script: "cd /home/forge && ./deploy.sh",
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+describe("recipesList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list recipes", async () => {
+    const { listRecipes } = await import("@studiometa/forge-core");
+    vi.mocked(listRecipes).mockResolvedValue({ data: [mockRecipe] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await recipesList(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"Deploy Script"'));
+  });
+
+  it("should handle errors", async () => {
+    const { listRecipes } = await import("@studiometa/forge-core");
+    vi.mocked(listRecipes).mockRejectedValue(new Error("API error"));
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await recipesList(ctx);
+    expect(processExitSpy).toHaveBeenCalled();
+  });
+});
+
+describe("recipesGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get recipe by id", async () => {
+    const { getRecipe } = await import("@studiometa/forge-core");
+    vi.mocked(getRecipe).mockResolvedValue({ data: mockRecipe });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await recipesGet(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"Deploy Script"'));
+  });
+
+  it("should exit with error when no id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await recipesGet([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("recipesRun", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should run recipe on servers", async () => {
+    const { runRecipe } = await import("@studiometa/forge-core");
+    vi.mocked(runRecipe).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human", servers: "1,2,3" },
+    });
+
+    await recipesRun(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("dispatched"));
+  });
+
+  it("should exit with error when no id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", servers: "1" },
+    });
+
+    await recipesRun([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no servers", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await recipesRun(["1"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/recipes/handlers.ts
+++ b/packages/cli/src/commands/recipes/handlers.ts
@@ -1,0 +1,62 @@
+import { listRecipes, getRecipe, runRecipe } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function recipesList(ctx: CommandContext): Promise<void> {
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listRecipes({}, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function recipesGet(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+
+  if (!id) {
+    exitWithValidationError("id", "forge-cli recipes get <recipe_id>", ctx.formatter);
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getRecipe({ id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function recipesRun(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+  const serversRaw = String(ctx.options.servers ?? "");
+
+  if (!id) {
+    exitWithValidationError(
+      "id",
+      "forge-cli recipes run <recipe_id> --servers <ids>",
+      ctx.formatter,
+    );
+  }
+
+  if (!serversRaw) {
+    exitWithValidationError(
+      "servers",
+      "forge-cli recipes run <recipe_id> --servers <server_id1,server_id2,...>",
+      ctx.formatter,
+    );
+  }
+
+  const servers = serversRaw
+    .split(",")
+    .map((s) => Number(s.trim()))
+    .filter((n) => !isNaN(n));
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    await runRecipe({ id, servers }, execCtx);
+    ctx.formatter.success(`Recipe ${id} dispatched to ${servers.length} server(s).`);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/recipes/help.test.ts
+++ b/packages/cli/src/commands/recipes/help.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showRecipesHelp } from "./help.ts";
+
+describe("showRecipesHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showRecipesHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("recipes"));
+  });
+
+  it("should show list help", () => {
+    showRecipesHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("recipes list"));
+  });
+
+  it("should show list help for ls", () => {
+    showRecipesHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("recipes list"));
+  });
+
+  it("should show get help", () => {
+    showRecipesHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("recipe_id"));
+  });
+
+  it("should show run help", () => {
+    showRecipesHelp("run");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("servers"));
+  });
+});

--- a/packages/cli/src/commands/recipes/help.ts
+++ b/packages/cli/src/commands/recipes/help.ts
@@ -1,0 +1,46 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showRecipesHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli recipes list")} - List all recipes
+
+${colors.bold("USAGE:")}
+  forge-cli recipes list [options]
+`);
+  } else if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli recipes get")} - Get recipe details
+
+${colors.bold("USAGE:")}
+  forge-cli recipes get <recipe_id>
+`);
+  } else if (subcommand === "run") {
+    console.log(`
+${colors.bold("forge-cli recipes run")} - Run a recipe on servers
+
+${colors.bold("USAGE:")}
+  forge-cli recipes run <recipe_id> --servers <server_id1,server_id2,...>
+
+${colors.bold("OPTIONS:")}
+  --servers <ids>     Comma-separated server IDs to run recipe on
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli recipes")} - Manage recipes
+
+${colors.bold("USAGE:")}
+  forge-cli recipes <subcommand> [options]
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List all recipes
+  get <id>            Get recipe details
+  run <id>            Run a recipe on servers
+
+${colors.bold("OPTIONS:")}
+  -f, --format <fmt>  Output format: json, human, table
+
+Run ${colors.cyan("forge-cli recipes <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/recipes/index.ts
+++ b/packages/cli/src/commands/recipes/index.ts
@@ -1,0 +1,2 @@
+export { handleRecipesCommand } from "./command.ts";
+export { showRecipesHelp } from "./help.ts";

--- a/packages/cli/src/commands/servers/command.test.ts
+++ b/packages/cli/src/commands/servers/command.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleServersCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  serversList: vi.fn().mockResolvedValue(undefined),
+  serversGet: vi.fn().mockResolvedValue(undefined),
+  serversReboot: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: { format: "json" },
+    formatter: { output: vi.fn(), error: vi.fn() },
+    getToken: vi.fn().mockReturnValue("test-token"),
+    createExecutorContext: vi.fn(),
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleServersCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const handlers = await import("./handlers.ts");
+    vi.mocked(handlers.serversList).mockClear();
+    vi.mocked(handlers.serversGet).mockClear();
+    vi.mocked(handlers.serversReboot).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list subcommand", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleServersCommand("list", [], { format: "json" });
+    expect(handlers.serversList).toHaveBeenCalled();
+  });
+
+  it("should route ls alias", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleServersCommand("ls", [], {});
+    expect(handlers.serversList).toHaveBeenCalled();
+  });
+
+  it("should route get subcommand with args", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleServersCommand("get", ["123"], {});
+    expect(handlers.serversGet).toHaveBeenCalledWith(["123"], expect.anything());
+  });
+
+  it("should route reboot subcommand with args", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleServersCommand("reboot", ["123"], {});
+    expect(handlers.serversReboot).toHaveBeenCalledWith(["123"], expect.anything());
+  });
+
+  it("should exit with error for unknown subcommand", async () => {
+    await handleServersCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/servers/command.ts
+++ b/packages/cli/src/commands/servers/command.ts
@@ -1,0 +1,12 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { serversList, serversGet, serversReboot } from "./handlers.ts";
+
+export const handleServersCommand = createCommandRouter({
+  resource: "servers",
+  handlers: {
+    list: serversList,
+    ls: serversList,
+    get: [serversGet, "args"],
+    reboot: [serversReboot, "args"],
+  },
+});

--- a/packages/cli/src/commands/servers/handlers.test.ts
+++ b/packages/cli/src/commands/servers/handlers.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeServer } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { serversList, serversGet, serversReboot } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listServers: vi.fn(),
+  getServer: vi.fn(),
+  rebootServer: vi.fn(),
+}));
+
+const mockServer: ForgeServer = {
+  id: 1,
+  credential_id: 0,
+  name: "my-server",
+  type: "app",
+  provider: "ocean2",
+  provider_id: "abc",
+  size: "01",
+  region: "nyc3",
+  ubuntu_version: "22.04",
+  db_status: null,
+  redis_status: null,
+  php_version: "php83",
+  php_cli_version: "php83",
+  database_type: "mysql8",
+  ip_address: "1.2.3.4",
+  ssh_port: 22,
+  private_ip_address: "10.0.0.1",
+  local_public_key: "ssh-rsa ...",
+  is_ready: true,
+  revoked: false,
+  created_at: "2024-01-01T00:00:00Z",
+  network: [],
+  tags: [],
+};
+
+describe("serversList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list servers in json format", async () => {
+    const { listServers } = await import("@studiometa/forge-core");
+    vi.mocked(listServers).mockResolvedValue({ data: [mockServer] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await serversList(ctx);
+    const logSpy = vi.mocked(console.log);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('"my-server"'));
+  });
+
+  it("should show message when no servers in human format", async () => {
+    const { listServers } = await import("@studiometa/forge-core");
+    vi.mocked(listServers).mockResolvedValue({ data: [] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human" },
+    });
+
+    await serversList(ctx);
+    const logSpy = vi.mocked(console.log);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("No servers found"));
+  });
+
+  it("should list servers in human format", async () => {
+    const { listServers } = await import("@studiometa/forge-core");
+    vi.mocked(listServers).mockResolvedValue({ data: [mockServer] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human" },
+    });
+
+    await serversList(ctx);
+    const logSpy = vi.mocked(console.log);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("my-server"));
+  });
+
+  it("should list servers in table format", async () => {
+    const { listServers } = await import("@studiometa/forge-core");
+    vi.mocked(listServers).mockResolvedValue({ data: [mockServer] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "table" },
+    });
+
+    await serversList(ctx);
+    const logSpy = vi.mocked(console.log);
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it("should handle API errors", async () => {
+    const { listServers } = await import("@studiometa/forge-core");
+    vi.mocked(listServers).mockRejectedValue(new Error("API error"));
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await serversList(ctx);
+    expect(processExitSpy).toHaveBeenCalled();
+  });
+});
+
+describe("serversGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get server by id", async () => {
+    const { getServer } = await import("@studiometa/forge-core");
+    vi.mocked(getServer).mockResolvedValue({ data: mockServer });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await serversGet(["1"], ctx);
+    const logSpy = vi.mocked(console.log);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('"my-server"'));
+  });
+
+  it("should exit with validation error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human" },
+    });
+
+    await serversGet([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3); // VALIDATION_ERROR
+  });
+
+  it("should handle API errors", async () => {
+    const { getServer } = await import("@studiometa/forge-core");
+    vi.mocked(getServer).mockRejectedValue(new Error("not found"));
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await serversGet(["999"], ctx);
+    expect(processExitSpy).toHaveBeenCalled();
+  });
+});
+
+describe("serversReboot", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should reboot server by id", async () => {
+    const { rebootServer } = await import("@studiometa/forge-core");
+    vi.mocked(rebootServer).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human" },
+    });
+
+    await serversReboot(["1"], ctx);
+    const logSpy = vi.mocked(console.log);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("reboot initiated"));
+  });
+
+  it("should exit with validation error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human" },
+    });
+
+    await serversReboot([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/servers/handlers.ts
+++ b/packages/cli/src/commands/servers/handlers.ts
@@ -1,0 +1,73 @@
+/**
+ * CLI handlers for servers commands.
+ * Delegates all HTTP logic to forge-core executors.
+ */
+
+import { listServers, getServer, rebootServer } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+/**
+ * List all servers.
+ */
+export async function serversList(ctx: CommandContext): Promise<void> {
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listServers({}, execCtx);
+
+    const format = String(ctx.options.format ?? ctx.options.f ?? "human");
+
+    if (format === "table" || format === "json") {
+      ctx.formatter.output(result.data);
+    } else {
+      if (result.data.length === 0) {
+        ctx.formatter.info("No servers found.");
+        return;
+      }
+      for (const server of result.data) {
+        console.log(
+          `${String(server.id).padEnd(8)} ${server.name.padEnd(30)} ${server.ip_address.padEnd(16)} ${server.is_ready ? "ready" : "provisioning"}`,
+        );
+      }
+    }
+  }, ctx.formatter);
+}
+
+/**
+ * Get a single server by ID.
+ */
+export async function serversGet(args: string[], ctx: CommandContext): Promise<void> {
+  const [server_id] = args;
+
+  if (!server_id) {
+    exitWithValidationError("server_id", "forge-cli servers get <server_id>", ctx.formatter);
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getServer({ server_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+/**
+ * Reboot a server.
+ */
+export async function serversReboot(args: string[], ctx: CommandContext): Promise<void> {
+  const [server_id] = args;
+
+  if (!server_id) {
+    exitWithValidationError("server_id", "forge-cli servers reboot <server_id>", ctx.formatter);
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    await rebootServer({ server_id }, execCtx);
+    ctx.formatter.success(`Server ${server_id} reboot initiated.`);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/servers/help.test.ts
+++ b/packages/cli/src/commands/servers/help.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showServersHelp } from "./help.ts";
+
+describe("showServersHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help when no subcommand", () => {
+    showServersHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("forge-cli servers"));
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("list"));
+  });
+
+  it("should show list help for list subcommand", () => {
+    showServersHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("servers list"));
+  });
+
+  it("should show list help for ls alias", () => {
+    showServersHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("servers list"));
+  });
+
+  it("should show get help", () => {
+    showServersHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("server_id"));
+  });
+
+  it("should show reboot help", () => {
+    showServersHelp("reboot");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("reboot"));
+  });
+});

--- a/packages/cli/src/commands/servers/help.ts
+++ b/packages/cli/src/commands/servers/help.ts
@@ -1,0 +1,77 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showServersHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli servers list")} - List all servers
+
+${colors.bold("USAGE:")}
+  forge-cli servers list [options]
+
+${colors.bold("OPTIONS:")}
+  --token <token>     Forge API token
+  -f, --format <fmt>  Output format: json, human, table (default: human)
+  --no-color          Disable colored output
+  -h, --help          Show this help
+
+${colors.bold("EXAMPLES:")}
+  forge-cli servers list
+  forge-cli servers list --format json
+`);
+  } else if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli servers get")} - Get server details
+
+${colors.bold("USAGE:")}
+  forge-cli servers get <server_id> [options]
+
+${colors.bold("ARGUMENTS:")}
+  <server_id>         Server ID (required)
+
+${colors.bold("OPTIONS:")}
+  -f, --format <fmt>  Output format: json, human, table
+
+${colors.bold("EXAMPLES:")}
+  forge-cli servers get 123
+  forge-cli servers get 123 --format json
+`);
+  } else if (subcommand === "reboot") {
+    console.log(`
+${colors.bold("forge-cli servers reboot")} - Reboot a server
+
+${colors.bold("USAGE:")}
+  forge-cli servers reboot <server_id> [options]
+
+${colors.bold("ARGUMENTS:")}
+  <server_id>         Server ID (required)
+
+${colors.bold("EXAMPLES:")}
+  forge-cli servers reboot 123
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli servers")} - Manage servers
+
+${colors.bold("USAGE:")}
+  forge-cli servers <subcommand> [options]
+
+${colors.bold("ALIASES:")}
+  forge-cli s
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List all servers
+  get <id>            Get server details
+  reboot <id>         Reboot a server
+
+${colors.bold("OPTIONS:")}
+  -f, --format <fmt>  Output format: json, human, table
+  -h, --help          Show help for a subcommand
+
+${colors.bold("EXAMPLES:")}
+  forge-cli servers list
+  forge-cli servers get 123
+
+Run ${colors.cyan("forge-cli servers <subcommand> --help")} for subcommand details.
+`);
+  }
+}

--- a/packages/cli/src/commands/servers/index.ts
+++ b/packages/cli/src/commands/servers/index.ts
@@ -1,0 +1,2 @@
+export { handleServersCommand } from "./command.ts";
+export { showServersHelp } from "./help.ts";

--- a/packages/cli/src/commands/sites/command.test.ts
+++ b/packages/cli/src/commands/sites/command.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleSitesCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  sitesList: vi.fn().mockResolvedValue(undefined),
+  sitesGet: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: { format: "json" },
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleSitesCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const handlers = await import("./handlers.ts");
+    vi.mocked(handlers.sitesList).mockClear();
+    vi.mocked(handlers.sitesGet).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list subcommand", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleSitesCommand("list", [], {});
+    expect(handlers.sitesList).toHaveBeenCalled();
+  });
+
+  it("should route ls alias", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleSitesCommand("ls", [], {});
+    expect(handlers.sitesList).toHaveBeenCalled();
+  });
+
+  it("should route get with args", async () => {
+    const handlers = await import("./handlers.ts");
+    await handleSitesCommand("get", ["1"], {});
+    expect(handlers.sitesGet).toHaveBeenCalledWith(["1"], expect.anything());
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleSitesCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/sites/command.ts
+++ b/packages/cli/src/commands/sites/command.ts
@@ -1,0 +1,11 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { sitesList, sitesGet } from "./handlers.ts";
+
+export const handleSitesCommand = createCommandRouter({
+  resource: "sites",
+  handlers: {
+    list: sitesList,
+    ls: sitesList,
+    get: [sitesGet, "args"],
+  },
+});

--- a/packages/cli/src/commands/sites/handlers.test.ts
+++ b/packages/cli/src/commands/sites/handlers.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeSite } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { sitesList, sitesGet } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listSites: vi.fn(),
+  getSite: vi.fn(),
+}));
+
+const mockSite: ForgeSite = {
+  id: 1,
+  server_id: 10,
+  name: "example.com",
+  aliases: [],
+  directory: "/public",
+  wildcards: false,
+  status: "installed",
+  repository: null,
+  repository_provider: null,
+  repository_branch: null,
+  repository_status: null,
+  quick_deploy: false,
+  deployment_status: null,
+  project_type: "php",
+  php_version: "php83",
+  app: null,
+  app_status: null,
+  slack_channel: null,
+  telegram_chat_id: null,
+  telegram_chat_title: null,
+  username: "forge",
+  deployment_url: "https://forge.laravel.com/deploy/xxx",
+  created_at: "2024-01-01T00:00:00Z",
+  telegram_secret: "",
+  tags: [],
+  is_secured: false,
+  discord_webhook_url: null,
+  teams_webhook_url: null,
+};
+
+describe("sitesList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list sites", async () => {
+    const { listSites } = await import("@studiometa/forge-core");
+    vi.mocked(listSites).mockResolvedValue({ data: [mockSite] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await sitesList(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"example.com"'));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await sitesList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("sitesGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get site by id", async () => {
+    const { getSite } = await import("@studiometa/forge-core");
+    vi.mocked(getSite).mockResolvedValue({ data: mockSite });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await sitesGet(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"example.com"'));
+  });
+
+  it("should exit with error when no site_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await sitesGet([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await sitesGet(["1"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/sites/handlers.ts
+++ b/packages/cli/src/commands/sites/handlers.ts
@@ -1,0 +1,52 @@
+import { listSites, getSite } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function sitesList(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli sites list --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listSites({ server_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function sitesGet(args: string[], ctx: CommandContext): Promise<void> {
+  const [site_id] = args;
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!site_id) {
+    exitWithValidationError(
+      "site_id",
+      "forge-cli sites get <site_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli sites get <site_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getSite({ server_id, site_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/sites/help.test.ts
+++ b/packages/cli/src/commands/sites/help.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showSitesHelp } from "./help.ts";
+
+describe("showSitesHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help when no subcommand", () => {
+    showSitesHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("forge-cli sites"));
+  });
+
+  it("should show list help", () => {
+    showSitesHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("sites list"));
+  });
+
+  it("should show list help for ls", () => {
+    showSitesHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("sites list"));
+  });
+
+  it("should show get help", () => {
+    showSitesHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("site_id"));
+  });
+});

--- a/packages/cli/src/commands/sites/help.ts
+++ b/packages/cli/src/commands/sites/help.ts
@@ -1,0 +1,56 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showSitesHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli sites list")} - List sites on a server
+
+${colors.bold("USAGE:")}
+  forge-cli sites list --server <server_id> [options]
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+
+${colors.bold("EXAMPLES:")}
+  forge-cli sites list --server 123
+  forge-cli sites list --server 123 --format json
+`);
+  } else if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli sites get")} - Get site details
+
+${colors.bold("USAGE:")}
+  forge-cli sites get <site_id> --server <server_id> [options]
+
+${colors.bold("ARGUMENTS:")}
+  <site_id>           Site ID (required)
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli sites")} - Manage sites
+
+${colors.bold("USAGE:")}
+  forge-cli sites <subcommand> [options]
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List sites on a server
+  get <id>            Get site details
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required for most commands)
+  -f, --format <fmt>  Output format: json, human, table
+  -h, --help          Show help for a subcommand
+
+${colors.bold("EXAMPLES:")}
+  forge-cli sites list --server 123
+  forge-cli sites get 456 --server 123
+
+Run ${colors.cyan("forge-cli sites <subcommand> --help")} for subcommand details.
+`);
+  }
+}

--- a/packages/cli/src/commands/sites/index.ts
+++ b/packages/cli/src/commands/sites/index.ts
@@ -1,0 +1,2 @@
+export { handleSitesCommand } from "./command.ts";
+export { showSitesHelp } from "./help.ts";

--- a/packages/cli/src/commands/ssh-keys/command.test.ts
+++ b/packages/cli/src/commands/ssh-keys/command.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleSshKeysCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  sshKeysList: vi.fn().mockResolvedValue(undefined),
+  sshKeysGet: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleSshKeysCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list", async () => {
+    const h = await import("./handlers.ts");
+    await handleSshKeysCommand("list", [], {});
+    expect(h.sshKeysList).toHaveBeenCalled();
+  });
+
+  it("should route get with args", async () => {
+    const h = await import("./handlers.ts");
+    await handleSshKeysCommand("get", ["1"], {});
+    expect(h.sshKeysGet).toHaveBeenCalledWith(["1"], expect.anything());
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleSshKeysCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/ssh-keys/command.ts
+++ b/packages/cli/src/commands/ssh-keys/command.ts
@@ -1,0 +1,11 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { sshKeysList, sshKeysGet } from "./handlers.ts";
+
+export const handleSshKeysCommand = createCommandRouter({
+  resource: "ssh-keys",
+  handlers: {
+    list: sshKeysList,
+    ls: sshKeysList,
+    get: [sshKeysGet, "args"],
+  },
+});

--- a/packages/cli/src/commands/ssh-keys/handlers.test.ts
+++ b/packages/cli/src/commands/ssh-keys/handlers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ForgeSshKey } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { sshKeysList, sshKeysGet } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listSshKeys: vi.fn(),
+  getSshKey: vi.fn(),
+}));
+
+const mockKey: ForgeSshKey = {
+  id: 1,
+  server_id: 10,
+  name: "my-key",
+  status: "installed",
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+describe("sshKeysList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list ssh keys", async () => {
+    const { listSshKeys } = await import("@studiometa/forge-core");
+    vi.mocked(listSshKeys).mockResolvedValue({ data: [mockKey] });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await sshKeysList(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"my-key"'));
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await sshKeysList(ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("sshKeysGet", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should get ssh key", async () => {
+    const { getSshKey } = await import("@studiometa/forge-core");
+    vi.mocked(getSshKey).mockResolvedValue({ data: mockKey });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await sshKeysGet(["1"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining('"my-key"'));
+  });
+
+  it("should exit with error when no key id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json", server: "10" },
+    });
+
+    await sshKeysGet([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with error when no server_id", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await sshKeysGet(["1"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/ssh-keys/handlers.ts
+++ b/packages/cli/src/commands/ssh-keys/handlers.ts
@@ -1,0 +1,52 @@
+import { listSshKeys, getSshKey } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+
+export async function sshKeysList(ctx: CommandContext): Promise<void> {
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli ssh-keys list --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await listSshKeys({ server_id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}
+
+export async function sshKeysGet(args: string[], ctx: CommandContext): Promise<void> {
+  const [id] = args;
+  const server_id = String(ctx.options.server ?? "");
+
+  if (!id) {
+    exitWithValidationError(
+      "ssh_key_id",
+      "forge-cli ssh-keys get <key_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  if (!server_id) {
+    exitWithValidationError(
+      "server_id",
+      "forge-cli ssh-keys get <key_id> --server <server_id>",
+      ctx.formatter,
+    );
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const result = await getSshKey({ server_id, id }, execCtx);
+    ctx.formatter.output(result.data);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/ssh-keys/help.test.ts
+++ b/packages/cli/src/commands/ssh-keys/help.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showSshKeysHelp } from "./help.ts";
+
+describe("showSshKeysHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showSshKeysHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("ssh-keys"));
+  });
+
+  it("should show list help", () => {
+    showSshKeysHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("ssh-keys list"));
+  });
+
+  it("should show list help for ls", () => {
+    showSshKeysHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("ssh-keys list"));
+  });
+
+  it("should show get help", () => {
+    showSshKeysHelp("get");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("key_id"));
+  });
+});

--- a/packages/cli/src/commands/ssh-keys/help.ts
+++ b/packages/cli/src/commands/ssh-keys/help.ts
@@ -1,0 +1,36 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showSshKeysHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge-cli ssh-keys list")} - List SSH keys on a server
+
+${colors.bold("USAGE:")}
+  forge-cli ssh-keys list --server <server_id> [options]
+`);
+  } else if (subcommand === "get") {
+    console.log(`
+${colors.bold("forge-cli ssh-keys get")} - Get SSH key details
+
+${colors.bold("USAGE:")}
+  forge-cli ssh-keys get <key_id> --server <server_id>
+`);
+  } else {
+    console.log(`
+${colors.bold("forge-cli ssh-keys")} - Manage SSH keys
+
+${colors.bold("USAGE:")}
+  forge-cli ssh-keys <subcommand> [options]
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List SSH keys
+  get <id>            Get SSH key details
+
+${colors.bold("OPTIONS:")}
+  --server <id>       Server ID (required)
+  -f, --format <fmt>  Output format: json, human, table
+
+Run ${colors.cyan("forge-cli ssh-keys <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/ssh-keys/index.ts
+++ b/packages/cli/src/commands/ssh-keys/index.ts
@@ -1,0 +1,2 @@
+export { handleSshKeysCommand } from "./command.ts";
+export { showSshKeysHelp } from "./help.ts";

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@studiometa/forge-api", () => ({
+  createConfigStore: vi.fn().mockReturnValue({}),
+  getToken: vi.fn().mockReturnValue(null),
+  setToken: vi.fn(),
+  deleteToken: vi.fn(),
+}));
+
+describe("getConfig", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.FORGE_API_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("should return token from CLI argument", async () => {
+    const { getConfig } = await import("./config.ts");
+    const config = getConfig({ token: "cli-token" });
+    expect(config.apiToken).toBe("cli-token");
+  });
+
+  it("should return token from stored config when no CLI arg", async () => {
+    const { getToken } = await import("@studiometa/forge-api");
+    vi.mocked(getToken).mockReturnValue("stored-token");
+    const { getConfig } = await import("./config.ts");
+    const config = getConfig({});
+    expect(config.apiToken).toBe("stored-token");
+  });
+
+  it("should return undefined when no token available", async () => {
+    const { getToken } = await import("@studiometa/forge-api");
+    vi.mocked(getToken).mockReturnValue(null);
+    const { getConfig } = await import("./config.ts");
+    const config = getConfig({});
+    expect(config.apiToken).toBeUndefined();
+  });
+
+  it("should prefer CLI arg over stored token", async () => {
+    const { getToken } = await import("@studiometa/forge-api");
+    vi.mocked(getToken).mockReturnValue("stored-token");
+    const { getConfig } = await import("./config.ts");
+    const config = getConfig({ token: "cli-token" });
+    expect(config.apiToken).toBe("cli-token");
+  });
+
+  it("should ignore non-string token CLI arg", async () => {
+    const { getToken } = await import("@studiometa/forge-api");
+    vi.mocked(getToken).mockReturnValue("stored-token");
+    const { getConfig } = await import("./config.ts");
+    const config = getConfig({ token: true });
+    expect(config.apiToken).toBe("stored-token");
+  });
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,34 @@
+/**
+ * Config loading for forge-cli.
+ *
+ * Resolution priority (highest to lowest):
+ * 1. CLI arguments (--token)
+ * 2. Environment variable (FORGE_API_TOKEN)
+ * 3. Config file (XDG-compliant)
+ */
+
+import { createConfigStore, getToken } from "@studiometa/forge-api";
+
+export interface ForgeCliConfig {
+  /** Forge API token */
+  apiToken: string | undefined;
+}
+
+/**
+ * Resolve config from multiple sources with priority order.
+ */
+export function getConfig(
+  cliOptions?: Record<string, string | boolean | string[]>,
+): ForgeCliConfig {
+  // 1. CLI argument --token
+  const cliToken = cliOptions?.token;
+
+  // 2. Environment variable / config file (handled by getToken)
+  const storedToken = getToken(createConfigStore());
+
+  return {
+    apiToken: typeof cliToken === "string" ? cliToken : (storedToken ?? undefined),
+  };
+}
+
+export { createConfigStore, getToken, setToken, deleteToken } from "@studiometa/forge-api";

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createContext, createTestContext } from "./context.ts";
+import { OutputFormatter } from "./output.ts";
+import { ConfigError } from "./errors.ts";
+
+vi.mock("./config.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config.ts")>();
+  return {
+    ...actual,
+    createConfigStore: vi.fn().mockReturnValue({}),
+    getToken: vi.fn().mockReturnValue(null),
+    setToken: vi.fn(),
+    deleteToken: vi.fn(),
+  };
+});
+
+vi.mock("@studiometa/forge-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@studiometa/forge-api")>();
+  return {
+    ...actual,
+    HttpClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+      this.get = vi.fn();
+      this.post = vi.fn();
+      this.put = vi.fn();
+      this.delete = vi.fn();
+    }),
+    createConfigStore: vi.fn().mockReturnValue({}),
+    getToken: vi.fn().mockReturnValue(null),
+  };
+});
+
+describe("createContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should create context with defaults", () => {
+    const ctx = createContext({});
+    expect(ctx.formatter).toBeInstanceOf(OutputFormatter);
+    expect(ctx.options).toEqual({});
+  });
+
+  it("should use format option for formatter", () => {
+    const ctx = createContext({ format: "json" });
+    expect(ctx.formatter).toBeInstanceOf(OutputFormatter);
+  });
+
+  it("should use f short option for format", () => {
+    const ctx = createContext({ f: "table" });
+    expect(ctx.formatter).toBeInstanceOf(OutputFormatter);
+  });
+
+  it("should default to human format", () => {
+    const ctx = createContext({});
+    expect(ctx.formatter).toBeInstanceOf(OutputFormatter);
+  });
+
+  describe("getToken", () => {
+    it("should return CLI token when provided", () => {
+      const ctx = createContext({ token: "cli-token" });
+      expect(ctx.getToken()).toBe("cli-token");
+    });
+
+    it("should return stored token when no CLI token", async () => {
+      const { getToken } = await import("./config.ts");
+      vi.mocked(getToken).mockReturnValue("stored-token");
+
+      const ctx = createContext({});
+      expect(ctx.getToken()).toBe("stored-token");
+    });
+
+    it("should throw ConfigError when no token available", async () => {
+      const { getToken } = await import("./config.ts");
+      vi.mocked(getToken).mockReturnValue(null);
+
+      const ctx = createContext({});
+      expect(() => ctx.getToken()).toThrow(ConfigError);
+    });
+
+    it("should ignore empty string token", async () => {
+      const { getToken } = await import("./config.ts");
+      vi.mocked(getToken).mockReturnValue("fallback-token");
+
+      const ctx = createContext({ token: "" });
+      expect(ctx.getToken()).toBe("fallback-token");
+    });
+  });
+
+  describe("createExecutorContext", () => {
+    it("should create executor context with HttpClient", () => {
+      const ctx = createContext({ token: "my-token" });
+      const execCtx = ctx.createExecutorContext("my-token");
+      expect(execCtx.client).toBeDefined();
+    });
+  });
+});
+
+describe("createTestContext", () => {
+  it("should create context with default test values", () => {
+    const ctx = createTestContext({});
+    expect(ctx.formatter).toBeInstanceOf(OutputFormatter);
+    expect(ctx.options.format).toBe("json");
+    expect(ctx.options["no-color"]).toBe(true);
+  });
+
+  it("should return test-token by default", () => {
+    const ctx = createTestContext({});
+    expect(ctx.getToken()).toBe("test-token");
+  });
+
+  it("should return provided token", () => {
+    const ctx = createTestContext({ token: "my-test-token" });
+    expect(ctx.getToken()).toBe("my-test-token");
+  });
+
+  it("should return token from options", () => {
+    const ctx = createTestContext({ options: { token: "opts-token" } });
+    expect(ctx.getToken()).toBe("opts-token");
+  });
+
+  it("should allow overriding formatter", () => {
+    const customFormatter = new OutputFormatter("json", true);
+    const ctx = createTestContext({ formatter: customFormatter });
+    expect(ctx.formatter).toBe(customFormatter);
+  });
+
+  it("should throw when createExecutorContext called without mockClient", () => {
+    const ctx = createTestContext({});
+    expect(() => ctx.createExecutorContext("token")).toThrow("provide mockClient");
+  });
+
+  it("should return mockClient in createExecutorContext when provided", () => {
+    const mockClient = { get: vi.fn() } as never;
+    const ctx = createTestContext({ mockClient });
+    const execCtx = ctx.createExecutorContext("token");
+    expect(execCtx.client).toBe(mockClient);
+  });
+});

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -1,0 +1,113 @@
+/**
+ * CLI execution context with dependency injection.
+ *
+ * Instead of hidden dependencies in command handlers, this module provides
+ * explicit dependency passing for testability and transparency.
+ */
+
+import type { HttpClient } from "@studiometa/forge-api";
+import type { ExecutorContext } from "@studiometa/forge-core";
+
+import type { OutputFormat } from "./types.ts";
+
+import { HttpClient as ForgeHttpClient } from "@studiometa/forge-api";
+import { ConfigError } from "./errors.ts";
+import { createConfigStore, getToken } from "./config.ts";
+import { OutputFormatter } from "./output.ts";
+
+export interface CommandOptions {
+  [key: string]: string | boolean | string[] | undefined;
+  format?: string;
+  f?: string;
+  token?: string;
+  "no-color"?: boolean;
+}
+
+/**
+ * Context containing all dependencies needed by command handlers.
+ */
+export interface CommandContext {
+  /** Output formatter for the current format */
+  readonly formatter: OutputFormatter;
+  /** Raw CLI options */
+  readonly options: CommandOptions;
+  /** Create an ExecutorContext from this command context */
+  createExecutorContext(token: string): ExecutorContext;
+  /** Resolve the API token or throw ConfigError */
+  getToken(): string;
+}
+
+/**
+ * Creates a command context from CLI options.
+ */
+export function createContext(options: CommandOptions = {}): CommandContext {
+  const format = (options.format ?? options.f ?? "human") as OutputFormat;
+  const noColor = options["no-color"] === true;
+  const formatter = new OutputFormatter(format, noColor);
+
+  return {
+    formatter,
+    options,
+
+    createExecutorContext(token: string): ExecutorContext {
+      const client = new ForgeHttpClient({ token }) as unknown as HttpClient;
+      return { client };
+    },
+
+    getToken(): string {
+      // 1. CLI arg
+      if (typeof options.token === "string" && options.token) {
+        return options.token;
+      }
+      // 2. Env var / config file
+      const stored = getToken(createConfigStore());
+      if (stored) {
+        return stored;
+      }
+      // 3. Not found — throw
+      throw ConfigError.missingToken();
+    },
+  };
+}
+
+/**
+ * Creates a test context for unit tests.
+ *
+ * @example
+ * ```typescript
+ * const ctx = createTestContext({
+ *   mockClient: { get: async () => ({ servers: [] }) } as never,
+ * });
+ * ```
+ */
+export function createTestContext(overrides: {
+  options?: CommandOptions;
+  formatter?: OutputFormatter;
+  token?: string;
+  mockClient?: HttpClient;
+}): CommandContext {
+  const opts: CommandOptions = overrides.options ?? {
+    format: "json",
+    "no-color": true,
+  };
+  const format = (opts.format ?? "json") as OutputFormat;
+  const formatter = overrides.formatter ?? new OutputFormatter(format, true);
+
+  return {
+    formatter,
+    options: opts,
+    createExecutorContext(_token: string): ExecutorContext {
+      if (!overrides.mockClient) {
+        throw new Error(
+          "createTestContext: provide mockClient to use createExecutorContext in tests",
+        );
+      }
+      return { client: overrides.mockClient };
+    },
+    getToken(): string {
+      if (overrides.token) return overrides.token;
+      if (typeof opts.token === "string") return opts.token;
+      return "test-token";
+    },
+  };
+}

--- a/packages/cli/src/error-handler.test.ts
+++ b/packages/cli/src/error-handler.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { OutputFormatter } from "./output.ts";
+import { ApiError, ConfigError, ValidationError } from "./errors.ts";
+import {
+  ExitCode,
+  getExitCode,
+  handleError,
+  runCommand,
+  exitWithValidationError,
+} from "./error-handler.ts";
+
+describe("getExitCode", () => {
+  it("should return VALIDATION_ERROR for ValidationError", () => {
+    expect(getExitCode(ValidationError.required("id"))).toBe(ExitCode.VALIDATION_ERROR);
+  });
+
+  it("should return AUTHENTICATION_ERROR for 401 ApiError", () => {
+    expect(getExitCode(new ApiError("Unauthorized", 401))).toBe(ExitCode.AUTHENTICATION_ERROR);
+  });
+
+  it("should return NOT_FOUND_ERROR for 404 ApiError", () => {
+    expect(getExitCode(new ApiError("Not Found", 404))).toBe(ExitCode.NOT_FOUND_ERROR);
+  });
+
+  it("should return GENERAL_ERROR for other ApiError", () => {
+    expect(getExitCode(new ApiError("Server error", 500))).toBe(ExitCode.GENERAL_ERROR);
+  });
+
+  it("should return CONFIG_ERROR for ConfigError", () => {
+    expect(getExitCode(ConfigError.missingToken())).toBe(ExitCode.CONFIG_ERROR);
+  });
+
+  it("should return GENERAL_ERROR for unknown errors", () => {
+    expect(getExitCode(new Error("unknown"))).toBe(ExitCode.GENERAL_ERROR);
+    expect(getExitCode("string error")).toBe(ExitCode.GENERAL_ERROR);
+  });
+});
+
+describe("handleError", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call process.exit by default", () => {
+    const formatter = new OutputFormatter("human", true);
+    handleError(new Error("oops"), formatter);
+    expect(processExitSpy).toHaveBeenCalledWith(ExitCode.GENERAL_ERROR);
+  });
+
+  it("should not call process.exit when exit=false", () => {
+    const formatter = new OutputFormatter("human", true);
+    handleError(new Error("oops"), formatter, { exit: false });
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  it("should return exit code when exit=false", () => {
+    const formatter = new OutputFormatter("human", true);
+    const code = handleError(ValidationError.required("id"), formatter, { exit: false });
+    expect(code).toBe(ExitCode.VALIDATION_ERROR);
+  });
+
+  it("should output JSON error for json format", () => {
+    const formatter = new OutputFormatter("json", true);
+    (formatter as unknown as { format: string }).format = "json";
+    handleError(new ApiError("Not Found", 404), formatter, { exit: false });
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('"API_ERROR"'));
+  });
+
+  it("should output human error for human format", () => {
+    const formatter = new OutputFormatter("human", true);
+    handleError(new ApiError("Not Found", 404), formatter, { exit: false });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Not Found"));
+  });
+
+  it("should wrap non-CliError in ApiError", () => {
+    const formatter = new OutputFormatter("human", true);
+    handleError(new Error("raw error"), formatter, { exit: false });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("raw error"));
+  });
+});
+
+describe("runCommand", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return result on success", async () => {
+    const formatter = new OutputFormatter("json", true);
+    const result = await runCommand(async () => "done", formatter);
+    expect(result).toBe("done");
+  });
+
+  it("should handle errors and call process.exit", async () => {
+    const formatter = new OutputFormatter("human", true);
+    await runCommand(async () => {
+      throw new Error("fail");
+    }, formatter);
+    expect(processExitSpy).toHaveBeenCalled();
+  });
+});
+
+describe("exitWithValidationError", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call process.exit with VALIDATION_ERROR code", () => {
+    const formatter = new OutputFormatter("human", true);
+    try {
+      exitWithValidationError("server_id", "forge-cli servers get <server_id>", formatter);
+    } catch {
+      // process.exit is mocked so exitWithValidationError throws
+    }
+    expect(processExitSpy).toHaveBeenCalledWith(ExitCode.VALIDATION_ERROR);
+  });
+});

--- a/packages/cli/src/error-handler.ts
+++ b/packages/cli/src/error-handler.ts
@@ -1,0 +1,110 @@
+/**
+ * Centralized error handling for forge-cli.
+ */
+
+import type { OutputFormatter } from "./output.ts";
+
+import { ApiError, CliError, ConfigError, ValidationError, isCliError } from "./errors.ts";
+
+/**
+ * Exit codes for different error categories.
+ */
+export const ExitCode = {
+  SUCCESS: 0,
+  GENERAL_ERROR: 1,
+  AUTHENTICATION_ERROR: 2,
+  VALIDATION_ERROR: 3,
+  CONFIG_ERROR: 4,
+  NOT_FOUND_ERROR: 5,
+} as const;
+
+export type ExitCode = (typeof ExitCode)[keyof typeof ExitCode];
+
+/**
+ * Determine the appropriate exit code for an error.
+ */
+export function getExitCode(error: unknown): ExitCode {
+  if (error instanceof ValidationError) {
+    return ExitCode.VALIDATION_ERROR;
+  }
+  if (error instanceof ApiError) {
+    if (error.statusCode === 401) return ExitCode.AUTHENTICATION_ERROR;
+    if (error.statusCode === 404) return ExitCode.NOT_FOUND_ERROR;
+  }
+  if (isCliError(error) && error.code === "CONFIG_ERROR") {
+    return ExitCode.CONFIG_ERROR;
+  }
+  return ExitCode.GENERAL_ERROR;
+}
+
+/**
+ * Central error handler for all commands.
+ */
+export function handleError(
+  error: unknown,
+  formatter: OutputFormatter,
+  options?: { exit?: boolean },
+): ExitCode {
+  const shouldExit = options?.exit ?? true;
+
+  let cliError: CliError;
+  if (isCliError(error)) {
+    cliError = error;
+  } else {
+    cliError = ApiError.fromForgeError(error);
+  }
+
+  // Output error in appropriate format
+  const opts = formatter as unknown as { format?: string };
+  if (opts.format === "json") {
+    formatter.output(cliError.toJSON());
+  } else {
+    formatter.error(cliError.toFormattedMessage());
+  }
+
+  const exitCode = getExitCode(cliError);
+
+  if (shouldExit) {
+    process.exit(exitCode);
+  }
+
+  return exitCode;
+}
+
+/**
+ * Wraps a command function with automatic error handling.
+ */
+export async function runCommand<T>(
+  fn: () => Promise<T>,
+  formatter: OutputFormatter,
+): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (error) {
+    handleError(error, formatter);
+    return undefined; // unreachable due to process.exit
+  }
+}
+
+/**
+ * Exits with a validation error for a missing required argument.
+ */
+export function exitWithValidationError(
+  field: string,
+  usage: string,
+  formatter: OutputFormatter,
+): never {
+  const error = ValidationError.required(field, [`Usage: ${usage}`]);
+  handleError(error, formatter);
+  // Unreachable in production
+  throw error;
+}
+
+/**
+ * Exits with a config error when token is missing.
+ */
+export function exitWithConfigError(formatter: OutputFormatter): never {
+  const error = ConfigError.missingToken();
+  handleError(error, formatter);
+  throw error;
+}

--- a/packages/cli/src/errors.test.ts
+++ b/packages/cli/src/errors.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+
+import { CliError, ConfigError, ValidationError, ApiError, isCliError } from "./errors.ts";
+
+describe("ConfigError", () => {
+  it("should create missingToken error", () => {
+    const err = ConfigError.missingToken();
+    expect(err.code).toBe("CONFIG_ERROR");
+    expect(err.isRecoverable).toBe(true);
+    expect(err.message).toContain("token");
+    expect(err.hints).toBeDefined();
+    expect(err.hints!.length).toBeGreaterThan(0);
+  });
+
+  it("should include hints in formatted message", () => {
+    const err = ConfigError.missingToken();
+    const formatted = err.toFormattedMessage();
+    expect(formatted).toContain("Hints:");
+    expect(formatted).toContain("•");
+  });
+
+  it("should serialize to JSON", () => {
+    const err = ConfigError.missingToken();
+    const json = err.toJSON();
+    expect(json.error).toBe("CONFIG_ERROR");
+    expect(json.name).toBe("ConfigError");
+    expect(json.message).toBeTruthy();
+    expect(json.isRecoverable).toBe(true);
+    expect(json.hints).toBeDefined();
+  });
+
+  it("toFormattedMessage without hints returns just message", () => {
+    const err = new ConfigError("simple error");
+    const msg = err.toFormattedMessage();
+    expect(msg).toBe("simple error");
+  });
+
+  it("toJSON should include cause if it is an Error", () => {
+    const cause = new Error("root cause");
+    const err = new ConfigError("wrapper", undefined, cause);
+    const json = err.toJSON();
+    expect((json.cause as { message: string }).message).toBe("root cause");
+  });
+
+  it("toJSON should not include cause if it is not an Error", () => {
+    const err = new ConfigError("wrapper", undefined, "string cause");
+    const json = err.toJSON();
+    expect(json.cause).toBeUndefined();
+  });
+});
+
+describe("ValidationError", () => {
+  it("should create required error", () => {
+    const err = ValidationError.required("server_id");
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect(err.isRecoverable).toBe(true);
+    expect(err.message).toContain("server_id");
+    expect(err.field).toBe("server_id");
+  });
+
+  it("should include field in JSON", () => {
+    const err = ValidationError.required("site_id", ["Usage: forge-cli sites get <site_id>"]);
+    const json = err.toJSON();
+    expect(json.field).toBe("site_id");
+    expect(json.hints).toContain("Usage: forge-cli sites get <site_id>");
+  });
+
+  it("should create without hints", () => {
+    const err = ValidationError.required("id");
+    expect(err.hints).toBeUndefined();
+  });
+});
+
+describe("ApiError", () => {
+  it("should be non-recoverable for 401", () => {
+    const err = new ApiError("Unauthorized", 401);
+    expect(err.isRecoverable).toBe(false);
+    expect(err.hints).toContain("Check that your API token is valid");
+  });
+
+  it("should be non-recoverable for 403", () => {
+    const err = new ApiError("Forbidden", 403);
+    expect(err.isRecoverable).toBe(false);
+  });
+
+  it("should be non-recoverable for 404", () => {
+    const err = new ApiError("Not Found", 404);
+    expect(err.isRecoverable).toBe(false);
+    expect(err.hints).toContain("The resource may not exist");
+  });
+
+  it("should be recoverable for 429", () => {
+    const err = new ApiError("Rate limit", 429);
+    expect(err.isRecoverable).toBe(false);
+    expect(err.hints).toContain("Too many requests — wait before retrying");
+  });
+
+  it("should be recoverable for 500", () => {
+    const err = new ApiError("Server error", 500);
+    expect(err.isRecoverable).toBe(true);
+    expect(err.hints).toContain("Server error — try again later");
+  });
+
+  it("should be recoverable when no status code", () => {
+    const err = new ApiError("Network error");
+    expect(err.isRecoverable).toBe(true);
+  });
+
+  it("should have empty hints for non-special status codes", () => {
+    const err = new ApiError("Bad request", 400);
+    expect(err.hints).toEqual([]);
+  });
+
+  it("should include statusCode in JSON", () => {
+    const err = new ApiError("Not Found", 404);
+    const json = err.toJSON();
+    expect(json.statusCode).toBe(404);
+  });
+
+  it("fromForgeError should wrap Error with statusCode", () => {
+    const orig = Object.assign(new Error("API failed"), { statusCode: 404 });
+    const err = ApiError.fromForgeError(orig);
+    expect(err.statusCode).toBe(404);
+    expect(err.message).toBe("API failed");
+  });
+
+  it("fromForgeError should wrap plain Error", () => {
+    const orig = new Error("plain error");
+    const err = ApiError.fromForgeError(orig);
+    expect(err.message).toBe("plain error");
+    expect(err.statusCode).toBeUndefined();
+  });
+
+  it("fromForgeError should wrap unknown value", () => {
+    const err = ApiError.fromForgeError("some string");
+    expect(err.message).toBe("some string");
+  });
+});
+
+describe("isCliError", () => {
+  it("should return true for CliError instances", () => {
+    expect(isCliError(ConfigError.missingToken())).toBe(true);
+    expect(isCliError(ValidationError.required("x"))).toBe(true);
+    expect(isCliError(new ApiError("err"))).toBe(true);
+  });
+
+  it("should return false for non-CliError", () => {
+    expect(isCliError(new Error("plain"))).toBe(false);
+    expect(isCliError("string")).toBe(false);
+    expect(isCliError(null)).toBe(false);
+  });
+});
+
+describe("CliError abstract contract", () => {
+  it("should set name to constructor name", () => {
+    const err = ConfigError.missingToken();
+    expect(err.name).toBe("ConfigError");
+  });
+
+  it("ValidationError name should be ValidationError", () => {
+    const err = ValidationError.required("x");
+    expect(err.name).toBe("ValidationError");
+  });
+
+  it("should be an instance of Error", () => {
+    const err = ConfigError.missingToken();
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(CliError);
+  });
+});

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,146 @@
+/**
+ * Error types for forge-cli.
+ *
+ * Provides specific error types for different failure scenarios with
+ * recovery hints for both humans and AI agents.
+ */
+
+/**
+ * Base error class for all CLI errors.
+ */
+export abstract class CliError extends Error {
+  abstract readonly code: string;
+  abstract readonly isRecoverable: boolean;
+
+  constructor(
+    message: string,
+    public readonly hints?: string[],
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      error: this.code,
+      name: this.name,
+      message: this.message,
+      isRecoverable: this.isRecoverable,
+      ...(this.hints && this.hints.length > 0 ? { hints: this.hints } : {}),
+      ...(this.cause instanceof Error ? { cause: { message: this.cause.message } } : {}),
+    };
+  }
+
+  toFormattedMessage(): string {
+    let msg = this.message;
+    if (this.hints && this.hints.length > 0) {
+      msg += "\n\nHints:\n" + this.hints.map((h) => `  • ${h}`).join("\n");
+    }
+    return msg;
+  }
+}
+
+// ── Config Errors ────────────────────────────────────
+
+export class ConfigError extends CliError {
+  readonly code = "CONFIG_ERROR";
+  readonly isRecoverable = true;
+
+  static missingToken(): ConfigError {
+    return new ConfigError("API token not configured", [
+      "Set via CLI flag: --token <token>",
+      "Set via environment: export FORGE_API_TOKEN=<token>",
+      "Set via config: forge-cli config set YOUR_TOKEN",
+    ]);
+  }
+}
+
+// ── Validation Errors ────────────────────────────────
+
+export class ValidationError extends CliError {
+  readonly code = "VALIDATION_ERROR";
+  readonly isRecoverable = true;
+
+  constructor(
+    message: string,
+    public readonly field?: string,
+    hints?: string[],
+    cause?: unknown,
+  ) {
+    super(message, hints, cause);
+  }
+
+  override toJSON() {
+    return { ...super.toJSON(), field: this.field };
+  }
+
+  static required(field: string, hints?: string[]): ValidationError {
+    return new ValidationError(`${field} is required`, field, hints);
+  }
+}
+
+// ── API Errors ───────────────────────────────────────
+
+export class ApiError extends CliError {
+  readonly code = "API_ERROR";
+  readonly isRecoverable: boolean;
+
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    hints?: string[],
+    cause?: unknown,
+  ) {
+    super(message, hints ?? getApiErrorHints(statusCode), cause);
+    this.isRecoverable = statusCode === undefined || (statusCode >= 500 && statusCode < 600);
+  }
+
+  override toJSON() {
+    return { ...super.toJSON(), statusCode: this.statusCode };
+  }
+
+  static fromForgeError(error: unknown): ApiError {
+    if (error instanceof Error && "statusCode" in error) {
+      const e = error as Error & { statusCode?: number };
+      return new ApiError(e.message, e.statusCode, undefined, e);
+    }
+    if (error instanceof Error) {
+      return new ApiError(error.message, undefined, undefined, error);
+    }
+    return new ApiError(String(error));
+  }
+}
+
+function getApiErrorHints(statusCode?: number): string[] {
+  if (statusCode === 401) {
+    return ["Check that your API token is valid", "Set via: export FORGE_API_TOKEN=<token>"];
+  }
+  if (statusCode === 403) {
+    return ["You may not have permission to access this resource"];
+  }
+  if (statusCode === 404) {
+    return [
+      "The resource may not exist",
+      "Verify the ID is correct",
+      "Use the list command to find valid IDs",
+    ];
+  }
+  if (statusCode === 429) {
+    return ["Too many requests — wait before retrying"];
+  }
+  if (statusCode !== undefined && statusCode >= 500) {
+    return ["Server error — try again later"];
+  }
+  return [];
+}
+
+// ── Type Guards ──────────────────────────────────────
+
+export function isCliError(error: unknown): error is CliError {
+  return error instanceof CliError;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,10 @@
+// @studiometa/forge-cli
+// CLI for managing Laravel Forge servers, sites, and deployments
+
+export { createContext, createTestContext } from "./context.ts";
+export type { CommandContext, CommandOptions } from "./context.ts";
+export { OutputFormatter } from "./output.ts";
+export type { OutputFormat } from "./types.ts";
+export { CliError, ConfigError, ValidationError, ApiError, isCliError } from "./errors.ts";
+export { handleError, runCommand, ExitCode } from "./error-handler.ts";
+export { getConfig } from "./config.ts";

--- a/packages/cli/src/output.test.ts
+++ b/packages/cli/src/output.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { OutputFormatter } from "./output.ts";
+
+describe("OutputFormatter", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("JSON format", () => {
+    it("should output JSON", () => {
+      const formatter = new OutputFormatter("json");
+      const data = { key: "value" };
+
+      formatter.output(data);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(JSON.stringify(data, null, 2));
+    });
+
+    it("should output success as JSON", () => {
+      const formatter = new OutputFormatter("json");
+
+      formatter.success("Done");
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        JSON.stringify({ status: "success", message: "Done" }),
+      );
+    });
+
+    it("should output error as JSON", () => {
+      const formatter = new OutputFormatter("json");
+
+      formatter.error("Oops");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        JSON.stringify({ status: "error", message: "Oops", details: undefined }),
+      );
+    });
+
+    it("should output error with details as JSON", () => {
+      const formatter = new OutputFormatter("json");
+
+      formatter.error("Oops", { code: 404 });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        JSON.stringify({ status: "error", message: "Oops", details: { code: 404 } }),
+      );
+    });
+
+    it("should output warning as JSON", () => {
+      const formatter = new OutputFormatter("json");
+
+      formatter.warning("Watch out");
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        JSON.stringify({ status: "warning", message: "Watch out" }),
+      );
+    });
+
+    it("should output info as JSON", () => {
+      const formatter = new OutputFormatter("json");
+
+      formatter.info("FYI");
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        JSON.stringify({ status: "info", message: "FYI" }),
+      );
+    });
+  });
+
+  describe("Table format", () => {
+    it("should output table with headers and rows", () => {
+      const formatter = new OutputFormatter("table");
+      const data = [
+        { id: 1, name: "Server A" },
+        { id: 2, name: "Server B" },
+      ];
+
+      formatter.output(data);
+
+      const calls = consoleLogSpy.mock.calls.map((c) => c[0] as string);
+      expect(calls.some((c) => c.includes("id"))).toBe(true);
+      expect(calls.some((c) => c.includes("name"))).toBe(true);
+      expect(calls.some((c) => c.includes("-"))).toBe(true);
+      expect(calls.some((c) => c.includes("Server A"))).toBe(true);
+    });
+
+    it("should handle empty array", () => {
+      const formatter = new OutputFormatter("table");
+
+      formatter.output([]);
+
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+    });
+
+    it("should handle non-array data", () => {
+      const formatter = new OutputFormatter("table");
+
+      formatter.output("some string");
+
+      // Non-array data: no table output
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Human format", () => {
+    it("should output data as-is", () => {
+      const formatter = new OutputFormatter("human");
+
+      formatter.output("Some text");
+
+      expect(consoleLogSpy).toHaveBeenCalledWith("Some text");
+    });
+
+    it("should output success with checkmark", () => {
+      const formatter = new OutputFormatter("human");
+
+      formatter.success("Done!");
+
+      const output = consoleLogSpy.mock.calls[0][0] as string;
+      expect(output).toContain("✓");
+      expect(output).toContain("Done!");
+    });
+
+    it("should output error with cross", () => {
+      const formatter = new OutputFormatter("human");
+
+      formatter.error("Failed");
+
+      const output = consoleErrorSpy.mock.calls[0][0] as string;
+      expect(output).toContain("✗");
+      expect(output).toContain("Failed");
+    });
+
+    it("should output error details when provided", () => {
+      const formatter = new OutputFormatter("human");
+
+      formatter.error("Failed", "extra info");
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should output warning with symbol", () => {
+      const formatter = new OutputFormatter("human");
+
+      formatter.warning("Careful");
+
+      const output = consoleLogSpy.mock.calls[0][0] as string;
+      expect(output).toContain("⚠");
+    });
+
+    it("should output info message", () => {
+      const formatter = new OutputFormatter("human");
+
+      formatter.info("Here is info");
+
+      const output = consoleLogSpy.mock.calls[0][0] as string;
+      expect(output).toContain("Here is info");
+    });
+  });
+
+  describe("No-color mode", () => {
+    it("should still work with no-color", () => {
+      const formatter = new OutputFormatter("human", true);
+
+      formatter.success("OK");
+
+      const output = consoleLogSpy.mock.calls[0][0] as string;
+      expect(output).toContain("✓");
+    });
+  });
+});

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,93 @@
+import type { OutputFormat } from "./types.ts";
+
+import { colors } from "./utils/colors.ts";
+
+/**
+ * Output formatter for CLI commands.
+ * Supports human-readable, JSON, and table formats.
+ */
+export class OutputFormatter {
+  constructor(
+    private format: OutputFormat = "human",
+    private noColor: boolean = false,
+  ) {}
+
+  /**
+   * Output data in the configured format.
+   * Use format='json' for AI agents and structured data.
+   */
+  output(data: unknown): void {
+    switch (this.format) {
+      case "json":
+        console.log(JSON.stringify(data, null, 2));
+        break;
+      case "table":
+        this.outputTable(data);
+        break;
+      case "human":
+      default:
+        console.log(data);
+        break;
+    }
+  }
+
+  success(message: string): void {
+    if (this.format === "json") {
+      console.log(JSON.stringify({ status: "success", message }));
+    } else {
+      console.log(colors.green(`✓ ${message}`));
+    }
+  }
+
+  error(message: string, details?: unknown): void {
+    if (this.format === "json") {
+      console.error(JSON.stringify({ status: "error", message, details }));
+    } else {
+      console.error(colors.red(`✗ ${message}`));
+      if (details !== undefined) {
+        console.error(details);
+      }
+    }
+  }
+
+  warning(message: string): void {
+    if (this.format === "json") {
+      console.log(JSON.stringify({ status: "warning", message }));
+    } else {
+      console.log(colors.yellow(`⚠ ${message}`));
+    }
+  }
+
+  info(message: string): void {
+    if (this.format === "json") {
+      console.log(JSON.stringify({ status: "info", message }));
+    } else {
+      console.log(colors.cyan(message));
+    }
+  }
+
+  private outputTable(data: unknown): void {
+    if (Array.isArray(data) && data.length > 0) {
+      const headers = Object.keys(data[0] as Record<string, unknown>);
+      const colWidths = headers.map((h) => {
+        const maxDataWidth = Math.max(
+          ...data.map((row) => String((row as Record<string, unknown>)[h] ?? "").length),
+        );
+        return Math.max(h.length, maxDataWidth);
+      });
+
+      // Header
+      const headerRow = headers.map((h, i) => h.padEnd(colWidths[i])).join(" | ");
+      console.log(headerRow);
+      console.log(colWidths.map((w) => "-".repeat(w)).join("-+-"));
+
+      // Rows
+      for (const row of data) {
+        const rowStr = headers
+          .map((h, i) => String((row as Record<string, unknown>)[h] ?? "").padEnd(colWidths[i]))
+          .join(" | ");
+        console.log(rowStr);
+      }
+    }
+  }
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,9 @@
+// CLI-specific types for forge-cli
+
+export type OutputFormat = "json" | "human" | "table";
+
+export interface CliOptions {
+  format?: OutputFormat;
+  quiet?: boolean;
+  noColor?: boolean;
+}

--- a/packages/cli/src/utils/args.test.ts
+++ b/packages/cli/src/utils/args.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+
+import { parseArgs, getOption, hasFlag } from "./args.ts";
+
+describe("parseArgs", () => {
+  it("should parse command and subcommand", () => {
+    const result = parseArgs(["servers", "list"]);
+    expect(result.command).toEqual(["servers", "list"]);
+    expect(result.positional).toEqual([]);
+  });
+
+  it("should parse long options with equals", () => {
+    const result = parseArgs(["--format=json"]);
+    expect(result.options.format).toBe("json");
+  });
+
+  it("should parse long options with space", () => {
+    const result = parseArgs(["--format", "json"]);
+    expect(result.options.format).toBe("json");
+  });
+
+  it("should parse long flags", () => {
+    const result = parseArgs(["--help"]);
+    expect(result.options.help).toBe(true);
+  });
+
+  it("should parse short options", () => {
+    const result = parseArgs(["-f", "json"]);
+    expect(result.options.f).toBe("json");
+  });
+
+  it("should parse short flags", () => {
+    const result = parseArgs(["-h"]);
+    expect(result.options.h).toBe(true);
+  });
+
+  it("should parse multiple short flags", () => {
+    const result = parseArgs(["-vh"]);
+    expect(result.options.v).toBe(true);
+    expect(result.options.h).toBe(true);
+  });
+
+  it("should parse positional arguments after command and subcommand", () => {
+    const result = parseArgs(["servers", "get", "123"]);
+    expect(result.command).toEqual(["servers", "get"]);
+    expect(result.positional).toEqual(["123"]);
+  });
+
+  it("should parse mixed arguments", () => {
+    const result = parseArgs(["servers", "list", "--format", "json", "-v"]);
+    expect(result.command).toEqual(["servers", "list"]);
+    expect(result.positional).toEqual([]);
+    expect(result.options.format).toBe("json");
+    expect(result.options.v).toBe(true);
+  });
+
+  it("should handle no arguments", () => {
+    const result = parseArgs([]);
+    expect(result.command).toEqual([]);
+    expect(result.positional).toEqual([]);
+    expect(result.options).toEqual({});
+  });
+
+  it("should handle --no-color flag", () => {
+    const result = parseArgs(["--no-color"]);
+    expect(result.options["no-color"]).toBe(true);
+  });
+
+  it("should handle flag followed by another flag (not consuming next flag as value)", () => {
+    const result = parseArgs(["--help", "--format", "json"]);
+    expect(result.options.help).toBe(true);
+    expect(result.options.format).toBe("json");
+  });
+
+  it("should handle short flag followed by another flag", () => {
+    const result = parseArgs(["-h", "--version"]);
+    expect(result.options.h).toBe(true);
+    expect(result.options.version).toBe(true);
+  });
+
+  it("should treat more than 2 positional commands as positionals", () => {
+    const result = parseArgs(["servers", "get", "123", "456"]);
+    expect(result.command).toEqual(["servers", "get"]);
+    expect(result.positional).toEqual(["123", "456"]);
+  });
+});
+
+describe("getOption", () => {
+  it("should get option by first matching name", () => {
+    const options = { format: "json" };
+    const result = getOption(options, ["format", "f"]);
+    expect(result).toBe("json");
+  });
+
+  it("should get option by second name if first not found", () => {
+    const options = { f: "json" };
+    const result = getOption(options, ["format", "f"]);
+    expect(result).toBe("json");
+  });
+
+  it("should return default if not found", () => {
+    const options = {};
+    const result = getOption(options, ["format", "f"], "human");
+    expect(result).toBe("human");
+  });
+
+  it("should return undefined if not found and no default", () => {
+    const options = {};
+    const result = getOption(options, ["format", "f"]);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for boolean flags", () => {
+    const options = { help: true };
+    const result = getOption(options, ["help"]);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for array values", () => {
+    const options = { filter: ["a=1", "b=2"] };
+    const result = getOption(options, ["filter"]);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("hasFlag", () => {
+  it("should return true if flag exists", () => {
+    const options = { help: true };
+    const result = hasFlag(options, ["help", "h"]);
+    expect(result).toBe(true);
+  });
+
+  it("should return true for any matching name", () => {
+    const options = { h: true };
+    const result = hasFlag(options, ["help", "h"]);
+    expect(result).toBe(true);
+  });
+
+  it("should return false if flag not found", () => {
+    const options = {};
+    const result = hasFlag(options, ["help", "h"]);
+    expect(result).toBe(false);
+  });
+
+  it("should return false if option is string value", () => {
+    const options = { help: "yes" };
+    const result = hasFlag(options, ["help"]);
+    expect(result).toBe(false);
+  });
+});

--- a/packages/cli/src/utils/args.ts
+++ b/packages/cli/src/utils/args.ts
@@ -1,0 +1,88 @@
+/**
+ * Simple argument parser using native Node.js.
+ * Parses process.argv into a structured format with no external deps.
+ */
+
+export type OptionValue = string | boolean | string[];
+
+export interface ParsedArgs {
+  command: string[];
+  options: Record<string, OptionValue>;
+  positional: string[];
+}
+
+export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
+  const options: Record<string, string | boolean | string[]> = {};
+  const positional: string[] = [];
+  const command: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg.startsWith("--")) {
+      // Long option: --key=value or --key value or --flag
+      const equalIndex = arg.indexOf("=");
+      if (equalIndex > -1) {
+        const key = arg.slice(2, equalIndex);
+        const value = arg.slice(equalIndex + 1);
+        options[key] = value;
+      } else {
+        const key = arg.slice(2);
+        const nextArg = argv[i + 1];
+
+        if (nextArg !== undefined && !nextArg.startsWith("-")) {
+          options[key] = nextArg;
+          i++;
+        } else {
+          options[key] = true;
+        }
+      }
+    } else if (arg.startsWith("-") && arg.length > 1) {
+      // Short option: -k value or -abc (multiple flags)
+      if (arg.length === 2) {
+        const key = arg[1];
+        const nextArg = argv[i + 1];
+
+        if (nextArg !== undefined && !nextArg.startsWith("-")) {
+          options[key] = nextArg;
+          i++;
+        } else {
+          options[key] = true;
+        }
+      } else {
+        // Multiple short flags: -abc -> -a -b -c
+        for (let j = 1; j < arg.length; j++) {
+          options[arg[j]] = true;
+        }
+      }
+    } else {
+      // Positional argument or command
+      // First two non-option args are command and subcommand
+      if (command.length < 2) {
+        command.push(arg);
+      } else {
+        positional.push(arg);
+      }
+    }
+  }
+
+  return { command, options, positional };
+}
+
+export function getOption(
+  options: Record<string, OptionValue>,
+  names: string[],
+  defaultValue?: string,
+): string | undefined {
+  for (const name of names) {
+    if (name in options) {
+      const value = options[name];
+      return typeof value === "string" ? value : undefined;
+    }
+  }
+  return defaultValue;
+}
+
+export function hasFlag(options: Record<string, OptionValue>, names: string[]): boolean {
+  return names.some((name) => options[name] === true);
+}

--- a/packages/cli/src/utils/colors.test.ts
+++ b/packages/cli/src/utils/colors.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { colors, setColorEnabled, isColorEnabled } from "./colors.ts";
+
+describe("colors", () => {
+  afterEach(() => {
+    setColorEnabled(true);
+  });
+
+  it("should return colored text when colors enabled", () => {
+    setColorEnabled(true);
+    const result = colors.bold("hello");
+    expect(result).toContain("hello");
+    expect(result).toContain("\x1b[");
+  });
+
+  it("should return plain text when colors disabled", () => {
+    setColorEnabled(false);
+    const result = colors.bold("hello");
+    expect(result).toBe("hello");
+  });
+
+  it("isColorEnabled should reflect current state", () => {
+    setColorEnabled(true);
+    expect(isColorEnabled()).toBe(true);
+    setColorEnabled(false);
+    expect(isColorEnabled()).toBe(false);
+  });
+
+  it("should apply all color functions", () => {
+    setColorEnabled(true);
+    expect(colors.reset("x")).toContain("x");
+    expect(colors.bold("x")).toContain("x");
+    expect(colors.dim("x")).toContain("x");
+    expect(colors.red("x")).toContain("x");
+    expect(colors.green("x")).toContain("x");
+    expect(colors.yellow("x")).toContain("x");
+    expect(colors.cyan("x")).toContain("x");
+    expect(colors.gray("x")).toContain("x");
+  });
+
+  it("should strip ANSI codes when disabled", () => {
+    setColorEnabled(false);
+    expect(colors.red("error")).toBe("error");
+    expect(colors.green("ok")).toBe("ok");
+    expect(colors.reset("text")).toBe("text");
+  });
+});

--- a/packages/cli/src/utils/colors.ts
+++ b/packages/cli/src/utils/colors.ts
@@ -1,0 +1,43 @@
+/**
+ * ANSI color utilities using native Node.js.
+ * Provides terminal colors without external dependencies.
+ */
+
+// ANSI escape codes
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+
+// Foreground colors
+const FG_RED = "\x1b[31m";
+const FG_GREEN = "\x1b[32m";
+const FG_YELLOW = "\x1b[33m";
+const FG_CYAN = "\x1b[36m";
+const FG_GRAY = "\x1b[90m";
+
+// Colors enabled by default, disabled by NO_COLOR env var
+let colorEnabled = process.env.NO_COLOR === undefined;
+
+export function setColorEnabled(enabled: boolean): void {
+  colorEnabled = enabled;
+}
+
+export function isColorEnabled(): boolean {
+  return colorEnabled;
+}
+
+function colorize(text: string, code: string): string {
+  if (!colorEnabled) return text;
+  return `${code}${text}${RESET}`;
+}
+
+export const colors = {
+  reset: (text: string) => (colorEnabled ? `${RESET}${text}` : text),
+  bold: (text: string) => colorize(text, BOLD),
+  dim: (text: string) => colorize(text, DIM),
+  red: (text: string) => colorize(text, FG_RED),
+  green: (text: string) => colorize(text, FG_GREEN),
+  yellow: (text: string) => colorize(text, FG_YELLOW),
+  cyan: (text: string) => colorize(text, FG_CYAN),
+  gray: (text: string) => colorize(text, FG_GRAY),
+};

--- a/packages/cli/src/utils/command-router.test.ts
+++ b/packages/cli/src/utils/command-router.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createCommandRouter } from "./command-router.ts";
+
+// Mock context creation
+vi.mock("../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: { format: "json" },
+    formatter: {
+      output: vi.fn(),
+      error: vi.fn(),
+    },
+  }),
+}));
+
+// Mock OutputFormatter as a proper class constructor
+vi.mock("../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("createCommandRouter", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call a list handler for a matching subcommand", async () => {
+    const listHandler = vi.fn().mockResolvedValue(undefined);
+    const router = createCommandRouter({
+      resource: "servers",
+      handlers: {
+        list: listHandler,
+      },
+    });
+
+    await router("list", [], { format: "json" });
+    expect(listHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call an args handler with args and context", async () => {
+    const argsHandler = vi.fn().mockResolvedValue(undefined);
+    const router = createCommandRouter({
+      resource: "servers",
+      handlers: {
+        get: [argsHandler, "args"],
+      },
+    });
+
+    await router("get", ["123"], { format: "json" });
+    expect(argsHandler).toHaveBeenCalledWith(["123"], expect.anything());
+  });
+
+  it("should route alias subcommands", async () => {
+    const listHandler = vi.fn().mockResolvedValue(undefined);
+    const router = createCommandRouter({
+      resource: "servers",
+      handlers: {
+        list: listHandler,
+        ls: listHandler,
+      },
+    });
+
+    await router("ls", [], {});
+    expect(listHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("should exit with error for unknown subcommand", async () => {
+    const router = createCommandRouter({
+      resource: "servers",
+      handlers: {},
+    });
+
+    await router("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("should error with unknown subcommand message", async () => {
+    const router = createCommandRouter({
+      resource: "sites",
+      handlers: {},
+    });
+
+    await router("notexist", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("should use no-color option", async () => {
+    const { OutputFormatter } = await import("../output.ts");
+
+    const router = createCommandRouter({
+      resource: "servers",
+      handlers: {
+        list: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    await router("list", [], { "no-color": true });
+    expect(OutputFormatter).toHaveBeenCalledWith(expect.any(String), true);
+  });
+});

--- a/packages/cli/src/utils/command-router.ts
+++ b/packages/cli/src/utils/command-router.ts
@@ -1,0 +1,82 @@
+/**
+ * Generic command router factory for CLI commands.
+ *
+ * Eliminates boilerplate switch/case pattern in command routing.
+ *
+ * @example
+ * ```typescript
+ * import { createCommandRouter } from '../../utils/command-router.ts';
+ * import { serversList, serversGet } from './handlers.ts';
+ *
+ * export const handleServersCommand = createCommandRouter({
+ *   resource: 'servers',
+ *   handlers: {
+ *     list: serversList,
+ *     ls: serversList,
+ *     get: [serversGet, 'args'],
+ *   },
+ * });
+ * ```
+ */
+
+import type { CommandContext, CommandOptions } from "../context.ts";
+import type { OutputFormat } from "../types.ts";
+
+import { createContext } from "../context.ts";
+import { OutputFormatter } from "../output.ts";
+
+/**
+ * Handler that only receives context (e.g., list commands)
+ */
+export type ListHandler = (ctx: CommandContext) => Promise<void>;
+
+/**
+ * Handler that receives args and context (e.g., get/update commands)
+ */
+export type ArgsHandler = (args: string[], ctx: CommandContext) => Promise<void>;
+
+/**
+ * Handler definition - either a ListHandler or an ArgsHandler marked with 'args'
+ */
+export type Handler = ListHandler | [ArgsHandler, "args"];
+
+/**
+ * Configuration for the command router
+ */
+export interface CommandRouterConfig {
+  /** Resource name for error messages (e.g., 'servers', 'sites') */
+  resource: string;
+  /** Map of subcommand names to handlers */
+  handlers: Record<string, Handler>;
+}
+
+/**
+ * Creates a command router function that dispatches to the appropriate handler.
+ */
+export function createCommandRouter(config: CommandRouterConfig) {
+  return async function (
+    subcommand: string,
+    args: string[],
+    options: Record<string, string | boolean | string[]>,
+  ): Promise<void> {
+    const format = (options.format ?? options.f ?? "human") as OutputFormat;
+    const formatter = new OutputFormatter(format, options["no-color"] === true);
+
+    const ctx = createContext(options as CommandOptions);
+
+    const handler = config.handlers[subcommand];
+    if (!handler) {
+      formatter.error(`Unknown ${config.resource} subcommand: ${subcommand}`);
+      process.exit(1);
+      return; // Unreachable in production, but needed for tests where process.exit is mocked
+    }
+
+    if (Array.isArray(handler)) {
+      // ArgsHandler - receives args and context
+      await handler[0](args, ctx);
+    } else {
+      // ListHandler - receives only context
+      await handler(ctx);
+    }
+  };
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "allowImportingTsExtensions": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+
+import { createBuildConfig, createTestConfig, versionDefine } from "../../vite.config.base.ts";
+
+export default defineConfig({
+  define: versionDefine(),
+  build: createBuildConfig({
+    entry: {
+      index: "./src/index.ts",
+      cli: "./src/cli.ts",
+    },
+    external: [/^@studiometa\/forge-api/, /^@studiometa\/forge-core/],
+  }),
+  test: createTestConfig({
+    name: "cli",
+    coverageExclude: ["src/cli.ts", "src/index.ts", "src/types.ts"],
+    coverageThresholds: {
+      statements: 80,
+      branches: 70,
+      functions: 85,
+      lines: 80,
+    },
+  }),
+});


### PR DESCRIPTION
Closes #22

## Changes

- Added new `packages/cli` package (`@studiometa/forge-cli`) with a full CLI for managing Laravel Forge resources
- **Entry point** (`src/cli.ts`): command router with global help, version, `--no-color` support, and per-command help dispatch
- **Utilities**: `utils/args.ts` (native arg parser, no deps), `utils/colors.ts` (ANSI colors), `utils/command-router.ts` (factory eliminating switch/case boilerplate)
- **Core modules**: `context.ts` (DI via `createContext`/`createTestContext`), `output.ts` (`OutputFormatter` for json/human/table), `errors.ts` (typed error hierarchy with hints), `error-handler.ts` (central error handling, `runCommand`), `config.ts` (token resolution with XDG config)
- **Commands**: servers (list/get/reboot), sites (list/get), deployments (list/deploy), databases (list/get), daemons (list/get/restart), env (get/update), nginx (get/update), certificates (list/get/activate), firewall-rules (list/get), ssh-keys (list/get), recipes (list/get/run), config (set/get/delete)
- **Package**: `package.json` with `forge-cli` binary, `tsconfig.json`, `vite.config.ts` with coverage thresholds
- Updated root `package.json` build script to include `@studiometa/forge-cli`

## Testing

- 42 test files added (one per source file), 276 tests total
- Coverage: 99.48% statements, 98.92% branches, 99.18% functions, 99.47% lines — all thresholds pass (80/70/85/80)
- Edge cases covered: empty lists, missing required arguments, API errors, token not configured, all output formats (json/human/table), color/no-color modes