### PR TITLE
Add forge-cli to root README and create packages/cli/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,35 @@ The official Forge SDK exists only in PHP. This project fills the gap with a ful
 | Package                                     | Description                                            |
 | ------------------------------------------- | ------------------------------------------------------ |
 | [`@studiometa/forge-sdk`](./packages/sdk)   | **Fluent, chainable TypeScript SDK** for Laravel Forge |
+| [`@studiometa/forge-cli`](./packages/cli)   | CLI tool for managing Forge servers, sites, and more   |
 | [`@studiometa/forge-mcp`](./packages/mcp)   | MCP server for Claude Desktop and other MCP clients    |
 | [`@studiometa/forge-core`](./packages/core) | Shared business logic — executor functions with DI     |
 | [`@studiometa/forge-api`](./packages/api)   | Internal API client, types, config, and rate limiter   |
 
 ## Quick Start
+
+### CLI
+
+```bash
+npm install -g @studiometa/forge-cli
+```
+
+```bash
+# Save your API token
+forge-cli config set YOUR_FORGE_TOKEN
+
+# List all servers
+forge-cli servers list
+
+# List sites on a server
+forge-cli sites list --server 123
+
+# Deploy a site
+forge-cli deployments deploy --server 123 --site 456
+
+# Get JSON output (for scripting and AI agents)
+forge-cli servers list --format json
+```
 
 ### SDK
 
@@ -81,8 +105,10 @@ Add to your Claude Desktop config:
 ```
 forge-api   → (nothing)       # HTTP client, types, config, rate limiter
 forge-sdk   → forge-api       # Fluent chainable SDK (the hero package)
-forge-core  → forge-api       # Executors with DI for MCP
+forge-core  → forge-api       # Executors with DI for MCP and CLI
 forge-mcp   → forge-core      # MCP server (stdio transport)
+forge-cli   → forge-core      # CLI tool (human + AI agent use)
+            → forge-api
 ```
 
 ## Contributing

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,227 @@
+# @studiometa/forge-cli
+
+[![npm version](https://img.shields.io/npm/v/@studiometa/forge-cli?style=flat&colorB=3e63dd&colorA=414853)](https://www.npmjs.com/package/@studiometa/forge-cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat&colorB=3e63dd&colorA=414853)](https://opensource.org/licenses/MIT)
+
+CLI tool for managing Laravel Forge servers, sites, and deployments. Optimized for both AI agents and human users.
+
+## Installation
+
+```bash
+npm install -g @studiometa/forge-cli
+
+# Or use directly with npx
+npx @studiometa/forge-cli --help
+```
+
+## Configuration
+
+Credentials can be provided in three ways (highest priority first):
+
+1. **CLI argument**: `--token <token>`
+2. **Environment variable**: `FORGE_API_TOKEN`
+3. **Config file** (XDG-compliant):
+
+```bash
+forge-cli config set YOUR_FORGE_TOKEN
+forge-cli config get
+forge-cli config delete
+```
+
+| Platform | Config path                                             |
+| -------- | ------------------------------------------------------- |
+| Linux    | `~/.config/forge-tools/config.json`                     |
+| macOS    | `~/Library/Application Support/forge-tools/config.json` |
+| Windows  | `%APPDATA%/forge-tools/config.json`                     |
+
+## Commands
+
+```
+forge-cli <command> [subcommand] [options]
+```
+
+| Command          | Alias   | Description                                       |
+| ---------------- | ------- | ------------------------------------------------- |
+| `config`         |         | Manage CLI configuration (`set`, `get`, `delete`) |
+| `servers`        | `s`     | List, get, reboot servers                         |
+| `sites`          |         | List, get sites on a server                       |
+| `deployments`    | `d`     | List deployments, trigger deploys                 |
+| `databases`      | `db`    | List, get databases on a server                   |
+| `daemons`        |         | List, get, restart daemons on a server            |
+| `env`            |         | Get, update environment variables for a site      |
+| `nginx`          |         | Get, update Nginx configuration for a site        |
+| `certificates`   | `certs` | List, get, activate SSL certificates for a site   |
+| `firewall-rules` | `fw`    | List, get firewall rules on a server              |
+| `ssh-keys`       |         | List, get SSH keys on a server                    |
+| `recipes`        |         | List, get, run recipes                            |
+
+Run `forge-cli <command> --help` for detailed usage of each command.
+
+## Quick Start
+
+```bash
+# Save your API token
+forge-cli config set YOUR_FORGE_TOKEN
+
+# List all servers
+forge-cli servers list
+
+# List sites on a server
+forge-cli sites list --server 123
+
+# Deploy a site
+forge-cli deployments deploy --server 123 --site 456
+
+# Get environment variables
+forge-cli env get --server 123 --site 456
+```
+
+## Output Formats
+
+All list/get commands support `--format`:
+
+| Format | Flag             | Description                          |
+| ------ | ---------------- | ------------------------------------ |
+| Human  | `--format human` | Colored, readable output (default)   |
+| JSON   | `--format json`  | Structured JSON for programmatic use |
+| Table  | `--format table` | ASCII table                          |
+
+```bash
+forge-cli servers list --format json
+forge-cli sites list --server 123 --format table
+```
+
+## Command Reference
+
+### `config` — Manage configuration
+
+```bash
+forge-cli config set <token>   # Save API token to config file
+forge-cli config get           # Show current token (masked)
+forge-cli config delete        # Delete stored token
+```
+
+### `servers` (`s`) — Manage servers
+
+```bash
+forge-cli servers list                  # List all servers
+forge-cli servers get <id>              # Get server details
+forge-cli servers reboot <id>           # Reboot a server
+```
+
+### `sites` — Manage sites
+
+```bash
+forge-cli sites list --server <id>              # List sites on a server
+forge-cli sites get <site_id> --server <id>     # Get site details
+```
+
+### `deployments` (`d`) — Manage deployments
+
+```bash
+forge-cli deployments list --server <id> --site <id>    # List deployments
+forge-cli deployments deploy --server <id> --site <id>  # Trigger a deployment
+```
+
+### `databases` (`db`) — Manage databases
+
+```bash
+forge-cli databases list --server <id>              # List databases
+forge-cli databases get <db_id> --server <id>       # Get database details
+```
+
+### `daemons` — Manage background processes
+
+```bash
+forge-cli daemons list --server <id>                    # List daemons
+forge-cli daemons get <daemon_id> --server <id>         # Get daemon details
+forge-cli daemons restart <daemon_id> --server <id>     # Restart a daemon
+```
+
+### `env` — Manage environment variables
+
+```bash
+forge-cli env get --server <id> --site <id>                             # Get .env content
+forge-cli env update --server <id> --site <id> --content "KEY=value"    # Update .env
+```
+
+### `nginx` — Manage Nginx configuration
+
+```bash
+forge-cli nginx get --server <id> --site <id>                               # Get Nginx config
+forge-cli nginx update --server <id> --site <id> --content "server { ... }" # Update Nginx config
+```
+
+### `certificates` (`certs`) — Manage SSL certificates
+
+```bash
+forge-cli certificates list --server <id> --site <id>               # List certificates
+forge-cli certificates get <cert_id> --server <id> --site <id>      # Get certificate details
+forge-cli certificates activate <cert_id> --server <id> --site <id> # Activate a certificate
+```
+
+### `firewall-rules` (`fw`) — Manage firewall rules
+
+```bash
+forge-cli firewall-rules list --server <id>                 # List firewall rules
+forge-cli firewall-rules get <rule_id> --server <id>        # Get rule details
+```
+
+### `ssh-keys` — Manage SSH keys
+
+```bash
+forge-cli ssh-keys list --server <id>               # List SSH keys
+forge-cli ssh-keys get <key_id> --server <id>       # Get SSH key details
+```
+
+### `recipes` — Manage recipes
+
+```bash
+forge-cli recipes list                                          # List all recipes
+forge-cli recipes get <id>                                      # Get recipe details
+forge-cli recipes run <id> --servers 123,456                    # Run recipe on servers
+```
+
+## Global Options
+
+| Option            | Alias | Description                                     |
+| ----------------- | ----- | ----------------------------------------------- |
+| `--token <token>` |       | Forge API token (overrides config and env)      |
+| `--server <id>`   |       | Server ID (required for server-scoped commands) |
+| `--site <id>`     |       | Site ID (required for site-scoped commands)     |
+| `--format <fmt>`  | `-f`  | Output format: `json`, `human`, `table`         |
+| `--no-color`      |       | Disable colored output                          |
+| `--help`          | `-h`  | Show help                                       |
+| `--version`       | `-v`  | Show version                                    |
+
+## AI Agent Integration
+
+The CLI is designed for programmatic use by AI agents:
+
+- Structured JSON output with `--format json`
+- Consistent error messages with non-zero exit codes
+- Fully non-interactive and scriptable
+
+```bash
+# Get all servers as JSON
+forge-cli servers list --format json
+
+# Deploy and capture output
+forge-cli deployments deploy --server 123 --site 456 --format json
+```
+
+## Requirements
+
+- **Node.js 24+**
+- **Laravel Forge account** with API token
+
+## Getting Your API Token
+
+1. Log into [Laravel Forge](https://forge.laravel.com)
+2. Go to **Account → API Tokens**
+3. Create a new token with the scopes you need
+4. Copy the token (it's only shown once)
+
+## License
+
+MIT © [Studio Meta](https://www.studiometa.fr)


### PR DESCRIPTION
Closes #37

## Changes

- **Root README.md**: Added `@studiometa/forge-cli` to the packages table with a description
- **Root README.md**: Added a CLI Quick Start section showing token configuration and common commands (`servers list`, `sites list`, `deployments deploy`, `servers list --format json`)
- **Root README.md**: Updated architecture diagram to show 5 packages with `forge-cli → forge-core, forge-api` dependencies
- **packages/cli/README.md**: Created new 178-line README covering:
  - Installation (`npm install -g` and `npx` usage)
  - Configuration (3-priority credential resolution, XDG config paths table)
  - Commands table with all 12 commands and their aliases
  - Quick Start examples
  - Output formats table (human, json, table)
  - Full command reference with all subcommands and options
  - Global options table
  - AI Agent Integration section
  - Requirements and API token instructions

## Testing

- Documentation-only change: no source files modified
- All CI checks pass: build, typecheck, lint, format, tests
- Coverage thresholds unaffected (no source changes)