### PR TITLE
Update CHANGELOG with recent PRs and prepare 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - DatabasesCollection (list, get, create, delete)
   - DaemonsCollection (list, get, create, delete, restart)
   - Dependency injection via fetch option for testing
+  - Add `createMockFetch()` test utility for SDK unit tests [[#24], [0af82b6]]
+  - Add `BaseCollection` abstract class; extend all SDK resource classes with it [[#25], [1f3c637]]
+  - Add `AsyncPaginatedIterator` and `all()` async iterator methods to collections [[#26], [1fc9788]]
+  - Add missing resource collections: backups, commands, scheduled-jobs, monitors, firewall-rules, ssh-keys, security-rules, redirect-rules, nginx-templates, recipes [[#41], [308d9f7]]
 
 - **Core** (`@studiometa/forge-core`):
   - ExecutorContext with DI for testability
@@ -46,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Monitors: list, get, create, delete
     - Nginx Templates: list, get, create, update, delete
     - Recipes: list, get, create, delete, run
+  - Add typed options interfaces per executor (`types.ts` per resource folder) [[#31], [453c9fd]]
+  - Move text formatting out of executors into the MCP layer [[#30], [ef97aa6]]
+  - Add database-users executors (list, get, create, delete, update-password) [[#40], [191271f]]
 
 - **MCP** (`@studiometa/forge-mcp`):
   - Stdio transport with MCP SDK integration
@@ -58,6 +65,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Hints system: contextual suggestions after get actions
   - Instructions loaded from SKILL.md for MCP client initialization
   - Pi skill (SKILL.md) with full resource reference and workflow examples
+  - Add `UserInputError` class and `ErrorMessages` constants [[#27], [c45f7a4]]
+  - Add HTTP transport (h3) alongside existing stdio transport [[#29], [9858b48]]
+  - Wire contextual hints end-to-end in `HandlerContext` and `createResourceHandler` [[#32], [7499b1a]]
+  - Add database-users MCP handler [[#40], [191271f]]
+
+- **MCP** (fixes):
+  - Fix compact output defaulting logic to use per-action default [[#28], [52bece0]]
+
+- **CLI** (`@studiometa/forge-cli`):
+  - Add `forge-cli` package — full command-line interface for managing Laravel Forge resources [[#33], [47826e1]]
+  - Add `forge-cli` to root README and create `packages/cli/README.md` [[#39], [a4a43f5]]
+  - Add CLI commands for backups, commands, scheduled-jobs, user, monitors, nginx-templates, security-rules, redirect-rules [[#42], [9865cd7]]
+  - Add database-users CLI commands [[#40], [191271f]]
 
 - **Infrastructure**:
   - Monorepo with npm workspaces (api → sdk → core → mcp)
@@ -70,3 +90,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CI workflow: lint, build, typecheck, test+coverage, semgrep
   - Publish workflow: npm publish with provenance on tag push
   - Documentation: README.md, CONTRIBUTING.md, CLAUDE.md, package READMEs
+
+[#24]: https://github.com/studiometa/forge-tools/pull/24
+[#25]: https://github.com/studiometa/forge-tools/pull/25
+[#26]: https://github.com/studiometa/forge-tools/pull/26
+[#27]: https://github.com/studiometa/forge-tools/pull/27
+[#28]: https://github.com/studiometa/forge-tools/pull/28
+[#29]: https://github.com/studiometa/forge-tools/pull/29
+[#30]: https://github.com/studiometa/forge-tools/pull/30
+[#31]: https://github.com/studiometa/forge-tools/pull/31
+[#32]: https://github.com/studiometa/forge-tools/pull/32
+[#33]: https://github.com/studiometa/forge-tools/pull/33
+[#39]: https://github.com/studiometa/forge-tools/pull/39
+[#40]: https://github.com/studiometa/forge-tools/pull/40
+[#41]: https://github.com/studiometa/forge-tools/pull/41
+[#42]: https://github.com/studiometa/forge-tools/pull/42
+[0af82b6]: https://github.com/studiometa/forge-tools/commit/0af82b6
+[1f3c637]: https://github.com/studiometa/forge-tools/commit/1f3c637
+[1fc9788]: https://github.com/studiometa/forge-tools/commit/1fc9788
+[308d9f7]: https://github.com/studiometa/forge-tools/commit/308d9f7
+[453c9fd]: https://github.com/studiometa/forge-tools/commit/453c9fd
+[ef97aa6]: https://github.com/studiometa/forge-tools/commit/ef97aa6
+[191271f]: https://github.com/studiometa/forge-tools/commit/191271f
+[c45f7a4]: https://github.com/studiometa/forge-tools/commit/c45f7a4
+[9858b48]: https://github.com/studiometa/forge-tools/commit/9858b48
+[7499b1a]: https://github.com/studiometa/forge-tools/commit/7499b1a
+[52bece0]: https://github.com/studiometa/forge-tools/commit/52bece0
+[47826e1]: https://github.com/studiometa/forge-tools/commit/47826e1
+[a4a43f5]: https://github.com/studiometa/forge-tools/commit/a4a43f5
+[9865cd7]: https://github.com/studiometa/forge-tools/commit/9865cd7


### PR DESCRIPTION
Closes #38

## Changes

- Updated `CHANGELOG.md` Unreleased section with entries for all 10 PRs merged on 2026-02-24 (#24–#33, #39–#42)
- Grouped new entries by package: SDK, Core, MCP, CLI
- Added link definitions at the bottom of the Unreleased section for all 14 PRs and their merge commits
- Kept existing initial-implementation entries intact

## PRs documented

- [#24] SDK: Add `createMockFetch()` test utility
- [#25] SDK: Add `BaseCollection` abstract class
- [#26] SDK: Add pagination support and `all()` async iterator
- [#27] MCP: Add `UserInputError` class and `ErrorMessages` constants
- [#28] MCP: Fix compact output defaulting logic
- [#29] MCP: Add HTTP transport (h3)
- [#30] Core: Move text formatting out of executors into MCP layer
- [#31] Core: Add typed options interfaces per executor
- [#32] MCP: Wire contextual hints end-to-end
- [#33] CLI: Add `forge-cli` package
- [#39] CLI: Add forge-cli to root README and create packages/cli/README.md
- [#40] All: Add database-users resource (core, MCP, SDK, CLI)
- [#41] SDK: Add missing resource collections
- [#42] CLI: Add commands for backups, commands, scheduled-jobs, user, monitors, nginx-templates, security-rules, redirect-rules