### PR TITLE
Update docs for deploy progress, shell completion, and audit logging

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -63,6 +63,7 @@ forge-cli <command> [subcommand] [options]
 | `redirect-rules`  |         | List, get, create, delete redirect rules for a site  |
 | `recipes`         |         | List, get, run recipes                               |
 | `user`            |         | Get the authenticated user's profile                 |
+| `completion`      |         | Install shell completion (bash, zsh, fish)           |
 
 Run `forge-cli <command> --help` for detailed usage of each command.
 
@@ -132,6 +133,8 @@ forge-cli deployments list --server <id> --site <id>    # List deployments
 forge-cli deployments deploy --server <id> --site <id>  # Trigger a deployment
 ```
 
+The `deploy` command waits for deployment to complete, showing live progress. On completion it prints the deployment log and elapsed time.
+
 ### `databases` (`db`) — Manage databases
 
 ```bash
@@ -190,6 +193,19 @@ forge-cli recipes list                                          # List all recip
 forge-cli recipes get <id>                                      # Get recipe details
 forge-cli recipes run <id> --servers 123,456                    # Run recipe on servers
 ```
+
+### `completion` — Shell completion
+
+```bash
+forge-cli completion bash           # Install Bash completion
+forge-cli completion zsh            # Install Zsh completion
+forge-cli completion fish           # Install Fish completion
+forge-cli completion bash --print   # Print script without installing
+```
+
+## Audit Logging
+
+All write operations (`deploy`, `create`, `delete`, `reboot`, `restart`, `update`, `run`, `activate`) are automatically logged to `~/.config/forge-tools/audit.log`. Override the path with the `FORGE_AUDIT_LOG` environment variable. Sensitive fields (tokens, passwords) are redacted.
 
 ## Global Options
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -56,6 +56,8 @@ import { RESOURCES, ACTIONS } from "@studiometa/forge-core";
 
 - `listDeployments({ server_id, site_id }, ctx)` — List deployments
 - `deploySite({ server_id, site_id }, ctx)` — Trigger deployment
+- `deploySiteAndWait({ server_id, site_id, timeout_ms?, poll_interval_ms? }, ctx)` — Deploy and poll until complete, returns `DeployResult` with status, log, and elapsed time
+- `getDeploymentLog({ server_id, site_id }, ctx)` — Get the latest deployment log
 - `getDeploymentOutput({ server_id, site_id, deployment_id }, ctx)` — Get output
 - `getDeploymentScript({ server_id, site_id }, ctx)` — Get deploy script
 - `updateDeploymentScript({ server_id, site_id, content }, ctx)` — Update script

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -88,6 +88,7 @@ Mutating operations. Annotated `destructiveHint: true` so MCP clients always pro
 
 ```json
 { "resource": "deployments", "action": "deploy", "server_id": "123", "site_id": "456" }
+// deploy blocks until complete, returning: status, deployment log, elapsed time
 { "resource": "servers", "action": "reboot", "id": "123" }
 { "resource": "daemons", "action": "create", "server_id": "123", "command": "php artisan queue:work" }
 ```

--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -105,11 +105,9 @@ Use `action: "schema"` for a compact machine-readable spec:
 // 2. Find the site (forge tool — read)
 { "resource": "sites", "action": "list", "server_id": "123" }
 
-// 3. Deploy (forge_write tool — write)
+// 3. Deploy (forge_write tool — write, blocks until complete)
 { "resource": "deployments", "action": "deploy", "server_id": "123", "site_id": "456" }
-
-// 4. Check deployment status (forge tool — read)
-{ "resource": "deployments", "action": "list", "server_id": "123", "site_id": "456" }
+// Returns: deployment status, log output, and elapsed time
 ```
 
 ### Check Server Status


### PR DESCRIPTION
Adds missing documentation:

- **CLI README**: Add `completion` command, audit logging section, deploy-wait behavior
- **Core README**: Add `deploySiteAndWait` and `getDeploymentLog` executors
- **MCP README**: Note that `deploy` now blocks until complete
- **SKILL.md**: Update deploy workflow (no longer needs manual status check)