### PR TITLE
Align MCP tools with SDK best practices

### DIFF
--- a/packages/mcp/src/handlers/types.ts
+++ b/packages/mcp/src/handlers/types.ts
@@ -2,9 +2,14 @@ import type { ExecutorContext } from "@studiometa/forge-core";
 
 /**
  * Result from MCP tool handlers.
+ *
+ * - `content` — human-readable text (always present)
+ * - `structuredContent` — machine-readable data matching the tool's `outputSchema`
+ * - `isError` — true when the result represents an error
  */
 export interface ToolResult {
   content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 

--- a/packages/mcp/src/handlers/utils.test.ts
+++ b/packages/mcp/src/handlers/utils.test.ts
@@ -15,6 +15,23 @@ describe("jsonResult", () => {
     const result = jsonResult({ name: "test", value: 42 });
     expect(result.content[0]!.text).toBe('{\n  "name": "test",\n  "value": 42\n}');
   });
+
+  it("should include structuredContent with success envelope for string data", () => {
+    const result = jsonResult("Hello");
+    expect(result.structuredContent).toEqual({ success: true, result: "Hello" });
+  });
+
+  it("should include structuredContent with success envelope for object data", () => {
+    const data = { name: "test", value: 42 };
+    const result = jsonResult(data);
+    expect(result.structuredContent).toEqual({ success: true, result: data });
+  });
+
+  it("should include structuredContent with success envelope for array data", () => {
+    const data = [{ id: 1 }, { id: 2 }];
+    const result = jsonResult(data);
+    expect(result.structuredContent).toEqual({ success: true, result: data });
+  });
 });
 
 describe("errorResult", () => {
@@ -22,6 +39,11 @@ describe("errorResult", () => {
     const result = errorResult("Something failed");
     expect(result.content[0]!.text).toContain("Error:");
     expect(result.isError).toBe(true);
+  });
+
+  it("should include structuredContent with error envelope", () => {
+    const result = errorResult("Something failed");
+    expect(result.structuredContent).toEqual({ success: false, error: "Something failed" });
   });
 });
 
@@ -45,6 +67,17 @@ describe("inputErrorResult", () => {
     expect(result.content[0]!.text).toContain("**Input Error:** Missing field");
     expect(result.content[0]!.text).toContain("- Hint A");
     expect(result.content[0]!.text).toContain("- Hint B");
+  });
+
+  it("should include structuredContent with error envelope for string", () => {
+    const result = inputErrorResult("Invalid input", "Try this instead");
+    expect(result.structuredContent).toEqual({ success: false, error: "Invalid input" });
+  });
+
+  it("should include structuredContent with error message from UserInputError", () => {
+    const error = new UserInputError("Missing field", ["Hint A"]);
+    const result = inputErrorResult(error);
+    expect(result.structuredContent).toEqual({ success: false, error: "Missing field" });
   });
 
   it("should render UserInputError without hints", () => {

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -76,6 +76,10 @@ export function createMcpServer(options?: HttpServerOptions): Server {
             text: "Error: Authentication required. No token found in request.",
           },
         ],
+        structuredContent: {
+          success: false,
+          error: "Authentication required. No token found in request.",
+        },
         isError: true,
       };
     }
@@ -90,6 +94,10 @@ export function createMcpServer(options?: HttpServerOptions): Server {
             text: "Error: Server is running in read-only mode. Write operations are disabled.",
           },
         ],
+        structuredContent: {
+          success: false,
+          error: "Server is running in read-only mode. Write operations are disabled.",
+        },
         isError: true,
       };
     }
@@ -107,6 +115,7 @@ export function createMcpServer(options?: HttpServerOptions): Server {
       /* v8 ignore stop */
       return {
         content: [{ type: "text" as const, text: `Error: ${message}` }],
+        structuredContent: { success: false, error: message },
         isError: true,
       };
     }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -81,6 +81,7 @@ export function createStdioServer(options?: StdioServerOptions): Server {
       const message = error instanceof Error ? error.message : String(error);
       return {
         content: [{ type: "text" as const, text: `Error: ${message}` }],
+        structuredContent: { success: false, error: message },
         isError: true,
       };
     }

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -30,27 +30,31 @@ export function handleConfigureTool(args: { apiToken: string }): ToolResult {
           text: "Error: apiToken is required and must be a non-empty string.",
         },
       ],
+      structuredContent: {
+        success: false,
+        error: "apiToken is required and must be a non-empty string.",
+      },
       isError: true,
     };
   }
 
   setToken(args.apiToken);
 
+  const maskedToken = `***${args.apiToken.slice(-4)}`;
+  const data = {
+    success: true,
+    message: "Laravel Forge API token configured successfully",
+    apiToken: maskedToken,
+  };
+
   return {
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            success: true,
-            message: "Laravel Forge API token configured successfully",
-            apiToken: `***${args.apiToken.slice(-4)}`,
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify(data, null, 2),
       },
     ],
+    structuredContent: data,
   };
 }
 
@@ -60,20 +64,19 @@ export function handleConfigureTool(args: { apiToken: string }): ToolResult {
 export function handleGetConfigTool(): ToolResult {
   const token = getToken();
 
+  const data = {
+    apiToken: token ? `***${token.slice(-4)}` : "not configured",
+    configured: !!token,
+  };
+
   return {
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            apiToken: token ? `***${token.slice(-4)}` : "not configured",
-            configured: !!token,
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify(data, null, 2),
       },
     ],
+    structuredContent: data,
   };
 }
 
@@ -115,6 +118,10 @@ export async function handleToolCall(
           text: "Error: Server is running in read-only mode. Write operations are disabled.",
         },
       ],
+      structuredContent: {
+        success: false,
+        error: "Server is running in read-only mode. Write operations are disabled.",
+      },
       isError: true,
     };
   }
@@ -130,6 +137,11 @@ export async function handleToolCall(
             text: 'Error: Forge API token not configured. Use "forge_configure" tool or set FORGE_API_TOKEN environment variable.',
           },
         ],
+        structuredContent: {
+          success: false,
+          error:
+            'Forge API token not configured. Use "forge_configure" tool or set FORGE_API_TOKEN environment variable.',
+        },
         isError: true,
       };
     }
@@ -144,6 +156,7 @@ export async function handleToolCall(
         text: `Error: Unknown tool "${name}".`,
       },
     ],
+    structuredContent: { success: false, error: `Unknown tool "${name}".` },
     isError: true,
   };
 }

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -21,9 +21,22 @@ describe("TOOLS", () => {
   describe("forge (read tool)", () => {
     const forgeTool = TOOLS.find((t) => t.name === "forge")!;
 
+    it("should have a top-level title", () => {
+      expect(forgeTool.title).toBe("Laravel Forge");
+    });
+
     it("should be annotated as read-only", () => {
       expect(forgeTool.annotations?.readOnlyHint).toBe(true);
       expect(forgeTool.annotations?.destructiveHint).toBe(false);
+    });
+
+    it("should have an outputSchema with success field", () => {
+      expect(forgeTool.outputSchema).toBeDefined();
+      expect(forgeTool.outputSchema!.type).toBe("object");
+      expect(forgeTool.outputSchema!.required).toContain("success");
+      expect(forgeTool.outputSchema!.properties).toHaveProperty("success");
+      expect(forgeTool.outputSchema!.properties).toHaveProperty("result");
+      expect(forgeTool.outputSchema!.properties).toHaveProperty("error");
     });
 
     it("should only allow read actions", () => {
@@ -65,9 +78,19 @@ describe("TOOLS", () => {
   describe("forge_write (write tool)", () => {
     const writeToolDef = TOOLS.find((t) => t.name === "forge_write")!;
 
+    it("should have a top-level title", () => {
+      expect(writeToolDef.title).toBe("Laravel Forge (Write)");
+    });
+
     it("should be annotated as destructive", () => {
       expect(writeToolDef.annotations?.readOnlyHint).toBe(false);
       expect(writeToolDef.annotations?.destructiveHint).toBe(true);
+    });
+
+    it("should have an outputSchema with success field", () => {
+      expect(writeToolDef.outputSchema).toBeDefined();
+      expect(writeToolDef.outputSchema!.type).toBe("object");
+      expect(writeToolDef.outputSchema!.required).toContain("success");
     });
 
     it("should only allow write actions", () => {
@@ -194,5 +217,32 @@ describe("STDIO_ONLY_TOOLS", () => {
     const names = STDIO_ONLY_TOOLS.map((t) => t.name);
     expect(names).toContain("forge_configure");
     expect(names).toContain("forge_get_config");
+  });
+
+  it("should have top-level titles on all stdio tools", () => {
+    for (const tool of STDIO_ONLY_TOOLS) {
+      expect(tool.title).toBeDefined();
+      expect(tool.title!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should have outputSchema on all stdio tools", () => {
+    for (const tool of STDIO_ONLY_TOOLS) {
+      expect(tool.outputSchema).toBeDefined();
+      expect(tool.outputSchema!.type).toBe("object");
+    }
+  });
+
+  it("forge_configure outputSchema should have success and message fields", () => {
+    const tool = STDIO_ONLY_TOOLS.find((t) => t.name === "forge_configure")!;
+    expect(tool.outputSchema!.properties).toHaveProperty("success");
+    expect(tool.outputSchema!.properties).toHaveProperty("message");
+    expect(tool.outputSchema!.properties).toHaveProperty("apiToken");
+  });
+
+  it("forge_get_config outputSchema should have configured and apiToken fields", () => {
+    const tool = STDIO_ONLY_TOOLS.find((t) => t.name === "forge_get_config")!;
+    expect(tool.outputSchema!.properties).toHaveProperty("configured");
+    expect(tool.outputSchema!.properties).toHaveProperty("apiToken");
   });
 });


### PR DESCRIPTION
Brings all MCP tool definitions in line with the latest MCP SDK (v1.26) standards:

- **SDK Tool type**: Replace local `interface Tool` with the SDK's `Tool` type for type safety
- **Top-level `title`**: Add `title` field to all 4 tools (used by clients like Claude Desktop for display)
- **`outputSchema`**: All tools now declare their output schema, enabling clients to parse `structuredContent`
- **`structuredContent`**: All handlers and error paths return `structuredContent` alongside `content`, with a consistent `{ success, result?, error? }` envelope
- **Property descriptions**: All write tool input properties now have descriptive text to help LLMs understand field semantics

19 new tests covering title, outputSchema, and structuredContent.