### PR TITLE
Fix MCP server not starting when invoked as node dist/index.js

### DIFF
--- a/packages/mcp/src/flags.test.ts
+++ b/packages/mcp/src/flags.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+describe("parseReadOnlyFlag", () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    delete process.env.FORGE_READ_ONLY;
+    process.argv = [...originalArgv];
+  });
+
+  afterEach(() => {
+    delete process.env.FORGE_READ_ONLY;
+    process.argv = originalArgv;
+  });
+
+  it("should return false with no flags", async () => {
+    const { parseReadOnlyFlag } = await import("./flags.ts");
+    expect(parseReadOnlyFlag()).toBe(false);
+  });
+
+  it("should return true when --read-only argv is present", async () => {
+    process.argv = [...originalArgv, "--read-only"];
+    const { parseReadOnlyFlag } = await import("./flags.ts");
+    expect(parseReadOnlyFlag()).toBe(true);
+  });
+
+  it("should return true when FORGE_READ_ONLY=true", async () => {
+    process.env.FORGE_READ_ONLY = "true";
+    const { parseReadOnlyFlag } = await import("./flags.ts");
+    expect(parseReadOnlyFlag()).toBe(true);
+  });
+});

--- a/packages/mcp/src/flags.ts
+++ b/packages/mcp/src/flags.ts
@@ -1,0 +1,21 @@
+/**
+ * CLI flag parsers shared between stdio and HTTP entry points.
+ *
+ * Extracted to a separate module so that both `index.ts` (stdio) and
+ * `server.ts` (HTTP) can import it without creating a shared dependency
+ * that triggers Vite code-splitting — which would break the `isMainModule`
+ * guard in `index.ts`.
+ *
+ * See: https://github.com/studiometa/forge-tools/issues/63
+ */
+
+/**
+ * Parse read-only flag from process.argv and environment.
+ *
+ * Supports:
+ * - `--read-only` CLI flag
+ * - `FORGE_READ_ONLY=true` environment variable
+ */
+export function parseReadOnlyFlag(): boolean {
+  return process.argv.includes("--read-only") || process.env.FORGE_READ_ONLY === "true";
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -27,9 +27,13 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
+import { parseReadOnlyFlag } from "./flags.ts";
 import { INSTRUCTIONS } from "./instructions.ts";
 import { getAvailableTools, handleToolCall } from "./stdio.ts";
 import { VERSION } from "./version.ts";
+
+// Re-export so consumers can still import from the main entry point
+export { parseReadOnlyFlag } from "./flags.ts";
 
 /**
  * Options for the stdio MCP server.
@@ -37,13 +41,6 @@ import { VERSION } from "./version.ts";
 export interface StdioServerOptions {
   /** When true, forge_write tool is not registered and write operations are rejected. */
   readOnly?: boolean;
-}
-
-/**
- * Parse read-only flag from process.argv and environment.
- */
-export function parseReadOnlyFlag(): boolean {
-  return process.argv.includes("--read-only") || process.env.FORGE_READ_ONLY === "true";
 }
 
 /**

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -26,7 +26,7 @@ import { toNodeHandler } from "h3/node";
 import { createServer, type Server } from "node:http";
 
 import { createHealthApp, createMcpRequestHandler } from "./http.ts";
-import { parseReadOnlyFlag } from "./index.ts";
+import { parseReadOnlyFlag } from "./flags.ts";
 import { SessionManager } from "./sessions.ts";
 import { VERSION } from "./version.ts";
 


### PR DESCRIPTION
Fixes #63

When MCP clients invoke the server as `node dist/index.js` instead of via the `.bin/forge-mcp` symlink, the auto-start guard never fires because Vite code-splits the guard into a shared chunk where `import.meta.url` doesn't match `process.argv[1]`.

**Root cause**: `server.ts` imports `parseReadOnlyFlag` from `index.ts`, creating a cross-entry-point dependency that triggers Vite code-splitting. The `createStdioServer`, `startStdioServer`, and `isMainModule` guard all get extracted to a shared chunk (`src-*.js`), leaving `dist/index.js` as a 4-line re-export stub.

**Fix**: Extract `parseReadOnlyFlag` to `flags.ts` so `server.ts` no longer imports from `index.ts`. This keeps the auto-start logic in `dist/index.js` where `import.meta.url` correctly matches `process.argv[1]`.