### PR TITLE
Make MCP dist entry points executable

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "dev": "vite build --watch",
-    "build": "vite build && tsc --emitDeclarationOnly",
+    "build": "vite build && tsc --emitDeclarationOnly && node scripts/postbuild.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ci": "vitest run --coverage",

--- a/packages/mcp/scripts/postbuild.js
+++ b/packages/mcp/scripts/postbuild.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { chmodSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const files = ["index.js", "server.js"];
+
+for (const file of files) {
+  const distFile = resolve(__dirname, "../dist", file);
+  try {
+    chmodSync(distFile, 0o755);
+    console.log("✓ Made dist/%s executable", file);
+  } catch (error) {
+    console.error("Failed to make dist/%s executable: %s", file, error.message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
npx creates a symlink to `dist/index.js` and expects it to be executable. Vite doesn't set the execute bit, causing `permission denied` when MCP clients invoke the server.

Adds a postbuild script (same pattern as productive-mcp) that `chmod 755` the bin entry points.