### PR TITLE
Add resolve() method to SDK ServersCollection and SitesCollection

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -34,7 +34,7 @@ export type { ScheduledJobListOptions } from "./resources/scheduled-jobs.ts";
 export { SecurityRulesCollection } from "./resources/security-rules.ts";
 export type { SecurityRuleListOptions } from "./resources/security-rules.ts";
 export { ServersCollection, ServerResource } from "./resources/servers.ts";
-export type { ServerListOptions } from "./resources/servers.ts";
+export type { ServerListOptions, ResolveMatch, ResolveResult } from "./resources/servers.ts";
 export { SshKeysCollection } from "./resources/ssh-keys.ts";
 export type { SshKeyListOptions } from "./resources/ssh-keys.ts";
 export {

--- a/packages/sdk/src/utils/name-matcher.test.ts
+++ b/packages/sdk/src/utils/name-matcher.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { matchByName } from "./name-matcher.ts";
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+const items: Item[] = [
+  { id: 1, name: "prod-web-1" },
+  { id: 2, name: "prod-web-2" },
+  { id: 3, name: "staging-web-1" },
+  { id: 4, name: "prod" },
+];
+
+describe("matchByName", () => {
+  it("should return partial matches", () => {
+    const { partial } = matchByName(items, "prod", (i) => i.name);
+    expect(partial).toHaveLength(3);
+    expect(partial.map((i) => i.id)).toEqual([1, 2, 4]);
+  });
+
+  it("should return exact matches", () => {
+    const { exact } = matchByName(items, "prod", (i) => i.name);
+    expect(exact).toHaveLength(1);
+    expect(exact[0]!.id).toBe(4);
+  });
+
+  it("should be case-insensitive", () => {
+    const { exact, partial } = matchByName(items, "PROD", (i) => i.name);
+    expect(exact).toHaveLength(1);
+    expect(exact[0]!.id).toBe(4);
+    expect(partial).toHaveLength(3);
+  });
+
+  it("should return empty arrays for no matches", () => {
+    const { exact, partial } = matchByName(items, "unknown", (i) => i.name);
+    expect(exact).toHaveLength(0);
+    expect(partial).toHaveLength(0);
+  });
+
+  it("should work with custom getName function", () => {
+    const domainItems = [
+      { id: 1, domain: "example.com" },
+      { id: 2, domain: "example.org" },
+      { id: 3, domain: "test.com" },
+    ];
+    const { partial } = matchByName(domainItems, "example", (i) => i.domain);
+    expect(partial).toHaveLength(2);
+  });
+
+  it("should handle empty items array", () => {
+    const { exact, partial } = matchByName([], "prod", (i: Item) => i.name);
+    expect(exact).toHaveLength(0);
+    expect(partial).toHaveLength(0);
+  });
+});

--- a/packages/sdk/src/utils/name-matcher.ts
+++ b/packages/sdk/src/utils/name-matcher.ts
@@ -1,0 +1,21 @@
+/**
+ * Result of a name matching operation.
+ */
+export interface NameMatch<T> {
+  exact: T[];
+  partial: T[];
+}
+
+/**
+ * Match items by name using case-insensitive exact and partial matching.
+ */
+export function matchByName<T>(
+  items: T[],
+  query: string,
+  getName: (item: T) => string,
+): NameMatch<T> {
+  const lower = query.toLowerCase();
+  const exact = items.filter((item) => getName(item).toLowerCase() === lower);
+  const partial = items.filter((item) => getName(item).toLowerCase().includes(lower));
+  return { exact, partial };
+}


### PR DESCRIPTION
Implements #76 — adds name-based resource lookup to the SDK.

## Changes

### SDK
- New `matchByName()` utility in `packages/sdk/src/utils/name-matcher.ts` (local copy, avoids forge-core dependency)
- `ServersCollection.resolve(query)` — find servers by name
- `SitesCollection.resolve(query)` — find sites by domain
- `ResolveMatch` and `ResolveResult` types exported from SDK index
- Comprehensive tests for resolve methods and matchByName utility

## API

```typescript
// Find servers matching "prod"
const result = await forge.servers.resolve("prod");
// → { query: "prod", matches: [{ id: 725393, name: "wilo-grove-prod" }], total: 1 }

// Find sites matching "example" on a server
const result = await forge.server(123).sites.resolve("example");
// → { query: "example", matches: [{ id: 456, name: "example.com" }], total: 1 }

// Compose with existing API
if (result.total === 1) {
  const sites = await forge.server(result.matches[0].id).sites.list();
}
```

## Design decision

Explicit `resolve()` method chosen over implicit `server("name")` because:
- No hidden network calls
- `server(id: number)` type stays pure and predictable
- Mirrors the MCP `resolve` action
- SDK stays a thin wrapper over the HTTP client

Closes #76