### PR TITLE
Add auto-resolve for names in server_id/site_id across all MCP calls (#75)

### DIFF
--- a/packages/mcp/src/handlers/auto-resolve.test.ts
+++ b/packages/mcp/src/handlers/auto-resolve.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import { autoResolveIds } from "./auto-resolve.ts";
+import type { CommonArgs } from "./types.ts";
+import type { ExecutorContext } from "@studiometa/forge-core";
+
+function createMockCtx(
+  servers: Array<{ id: number; name: string }> = [],
+  sites: Array<{ id: number; name: string }> = [],
+): ExecutorContext {
+  return {
+    client: {
+      get: async (url: string) => {
+        if (url === "/servers") return { servers };
+        if (url.match(/\/servers\/\d+\/sites$/)) return { sites };
+        return {};
+      },
+    } as never,
+  };
+}
+
+describe("autoResolveIds", () => {
+  it("should pass through numeric server_id unchanged (no API call)", async () => {
+    const ctx = createMockCtx(); // empty — would fail if called
+    const args: CommonArgs = { resource: "sites", action: "list", server_id: "123" };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.args.server_id).toBe("123");
+    }
+  });
+
+  it("should pass through numeric site_id unchanged", async () => {
+    const ctx = createMockCtx();
+    const args: CommonArgs = {
+      resource: "env",
+      action: "get",
+      server_id: "1",
+      site_id: "10",
+    };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.args.server_id).toBe("1");
+      expect(result.args.site_id).toBe("10");
+    }
+  });
+
+  it("should resolve non-numeric server_id with exact match", async () => {
+    const ctx = createMockCtx([{ id: 42, name: "prod-server" }]);
+    const args: CommonArgs = { resource: "sites", action: "list", server_id: "prod-server" };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.args.server_id).toBe("42");
+    }
+  });
+
+  it("should return error when non-numeric server_id has no match", async () => {
+    const ctx = createMockCtx([{ id: 1, name: "other-server" }]);
+    const args: CommonArgs = { resource: "sites", action: "list", server_id: "nonexistent" };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.isError).toBe(true);
+      expect(result.error.content[0]!.text).toContain('No server matching "nonexistent"');
+    }
+  });
+
+  it("should return error with match list when server_id is ambiguous (multiple matches)", async () => {
+    const ctx = createMockCtx([
+      { id: 1, name: "prod-web" },
+      { id: 2, name: "prod-worker" },
+    ]);
+    const args: CommonArgs = { resource: "sites", action: "list", server_id: "prod" };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.isError).toBe(true);
+      const text = result.error.content[0]!.text;
+      expect(text).toContain('Ambiguous server name "prod"');
+      expect(text).toContain("2 matches");
+      expect(text).toContain("prod-web");
+      expect(text).toContain("prod-worker");
+    }
+  });
+
+  it("should resolve non-numeric site_id after server_id", async () => {
+    const ctx = createMockCtx([{ id: 1, name: "my-server" }], [{ id: 99, name: "example.com" }]);
+    const args: CommonArgs = {
+      resource: "env",
+      action: "get",
+      server_id: "1",
+      site_id: "example.com",
+    };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.args.server_id).toBe("1");
+      expect(result.args.site_id).toBe("99");
+    }
+  });
+
+  it("should return error when non-numeric site_id has no match", async () => {
+    const ctx = createMockCtx([], [{ id: 10, name: "other.com" }]);
+    const args: CommonArgs = {
+      resource: "env",
+      action: "get",
+      server_id: "1",
+      site_id: "nonexistent.com",
+    };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.isError).toBe(true);
+      expect(result.error.content[0]!.text).toContain('No site matching "nonexistent.com"');
+    }
+  });
+
+  it("should return error with match list when site_id is ambiguous (multiple matches)", async () => {
+    const ctx = createMockCtx(
+      [],
+      [
+        { id: 10, name: "app.example.com" },
+        { id: 11, name: "api.example.com" },
+      ],
+    );
+    const args: CommonArgs = {
+      resource: "env",
+      action: "get",
+      server_id: "1",
+      site_id: "example",
+    };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.isError).toBe(true);
+      const text = result.error.content[0]!.text;
+      expect(text).toContain('Ambiguous site name "example"');
+      expect(text).toContain("app.example.com");
+      expect(text).toContain("api.example.com");
+    }
+  });
+
+  it("should return error when site_id is non-numeric but server_id is missing", async () => {
+    const ctx = createMockCtx();
+    const args: CommonArgs = {
+      resource: "env",
+      action: "get",
+      site_id: "example.com",
+    };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.isError).toBe(true);
+      expect(result.error.content[0]!.text).toContain(
+        "Cannot resolve site name without a server_id",
+      );
+    }
+  });
+
+  it("should resolve both non-numeric server_id and site_id", async () => {
+    const ctx = createMockCtx([{ id: 5, name: "prod" }], [{ id: 20, name: "example.com" }]);
+    const args: CommonArgs = {
+      resource: "env",
+      action: "get",
+      server_id: "prod",
+      site_id: "example.com",
+    };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.args.server_id).toBe("5");
+      expect(result.args.site_id).toBe("20");
+    }
+  });
+
+  it("should skip auto-resolve for resolve action", async () => {
+    // ctx with no servers — would error if API was called
+    const ctx = createMockCtx();
+    const args: CommonArgs = {
+      resource: "servers",
+      action: "resolve",
+      server_id: "prod",
+    };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // server_id should remain unchanged (non-numeric)
+      expect(result.args.server_id).toBe("prod");
+    }
+  });
+
+  it("should pass through unchanged when no server_id or site_id present", async () => {
+    const ctx = createMockCtx();
+    const args: CommonArgs = { resource: "servers", action: "list" };
+    const result = await autoResolveIds(args, ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.args.server_id).toBeUndefined();
+      expect(result.args.site_id).toBeUndefined();
+    }
+  });
+});

--- a/packages/mcp/src/handlers/auto-resolve.ts
+++ b/packages/mcp/src/handlers/auto-resolve.ts
@@ -1,0 +1,108 @@
+import type { ExecutorContext } from "@studiometa/forge-core";
+import { resolveServers, resolveSites } from "@studiometa/forge-core";
+import type { CommonArgs } from "./types.ts";
+import { errorResult } from "./utils.ts";
+import type { ToolResult } from "./types.ts";
+
+/**
+ * Check if a value is a numeric ID.
+ */
+function isNumericId(value: string): boolean {
+  return /^\d+$/.test(value);
+}
+
+/**
+ * Result of auto-resolution. Either the args are updated with resolved IDs,
+ * or an error result is returned.
+ */
+export type AutoResolveResult = { ok: true; args: CommonArgs } | { ok: false; error: ToolResult };
+
+/**
+ * Auto-resolve non-numeric server_id and site_id fields.
+ *
+ * Order matters: server_id is resolved first because site_id resolution
+ * requires a numeric server_id.
+ *
+ * Skipped for the 'resolve' action itself (it IS the resolve action).
+ */
+export async function autoResolveIds(
+  args: CommonArgs,
+  executorContext: ExecutorContext,
+): Promise<AutoResolveResult> {
+  // Don't auto-resolve for the resolve action itself
+  if (args.action === "resolve") {
+    return { ok: true, args };
+  }
+
+  const resolved = { ...args };
+
+  // Resolve server_id if non-numeric
+  if (resolved.server_id && !isNumericId(resolved.server_id)) {
+    const result = await resolveServers({ query: resolved.server_id }, executorContext);
+    const { matches, total } = result.data;
+
+    if (total === 0) {
+      return {
+        ok: false,
+        error: errorResult(
+          `No server matching "${resolved.server_id}". Use { resource: "servers", action: "resolve", query: "${resolved.server_id}" } to search.`,
+        ),
+      };
+    }
+
+    // Check for exact single match
+    const exactMatch = matches.length === 1 && total === 1;
+    if (!exactMatch && total > 1) {
+      const matchList = matches.map((m) => `  • ${m.name} (ID: ${m.id})`).join("\n");
+      return {
+        ok: false,
+        error: errorResult(
+          `Ambiguous server name "${resolved.server_id}" — ${total} matches found:\n${matchList}\n\nUse a more specific name or pass the numeric ID.`,
+        ),
+      };
+    }
+
+    resolved.server_id = String(matches[0]!.id);
+  }
+
+  // Resolve site_id if non-numeric (requires resolved server_id)
+  if (resolved.site_id && !isNumericId(resolved.site_id)) {
+    if (!resolved.server_id) {
+      return {
+        ok: false,
+        error: errorResult(
+          "Cannot resolve site name without a server_id. Provide server_id first.",
+        ),
+      };
+    }
+
+    const result = await resolveSites(
+      { server_id: resolved.server_id, query: resolved.site_id },
+      executorContext,
+    );
+    const { matches, total } = result.data;
+
+    if (total === 0) {
+      return {
+        ok: false,
+        error: errorResult(
+          `No site matching "${resolved.site_id}" on server ${resolved.server_id}. Use { resource: "sites", action: "resolve", server_id: "${resolved.server_id}", query: "${resolved.site_id}" } to search.`,
+        ),
+      };
+    }
+
+    if (total > 1) {
+      const matchList = matches.map((m) => `  • ${m.name} (ID: ${m.id})`).join("\n");
+      return {
+        ok: false,
+        error: errorResult(
+          `Ambiguous site name "${resolved.site_id}" — ${total} matches found:\n${matchList}\n\nUse a more specific name or pass the numeric ID.`,
+        ),
+      };
+    }
+
+    resolved.site_id = String(matches[0]!.id);
+  }
+
+  return { ok: true, args: resolved };
+}

--- a/packages/mcp/src/handlers/e2e.test.ts
+++ b/packages/mcp/src/handlers/e2e.test.ts
@@ -177,14 +177,16 @@ describe("E2E: executeToolWithCredentials", () => {
     expect(result.content[0]!.text).toContain("APP_ENV=production");
   });
 
-  it("should reject path traversal in server_id", async () => {
+  it("should reject non-matching server_id name (auto-resolve returns error)", async () => {
+    // "../etc" is non-numeric so auto-resolve attempts to match it as a name.
+    // The mock returns only "web-1" which doesn't match, so we get a resolve error.
     const result = await executeToolWithCredentials(
       "forge",
       { resource: "sites", action: "list", server_id: "../etc" },
       creds,
     );
     expect(result.isError).toBe(true);
-    expect(result.content[0]!.text).toContain("Invalid");
+    expect(result.content[0]!.text).toContain("No server matching");
   });
 
   it("should reject path traversal in id", async () => {
@@ -541,5 +543,40 @@ describe("E2E: executeToolWithCredentials", () => {
     expect(data._batch.total).toBe(2);
     expect(data._batch.succeeded).toBe(2);
     expect(data._batch.failed).toBe(0);
+  });
+
+  it("should auto-resolve non-numeric server_id to numeric ID end-to-end", async () => {
+    // The mock returns server "web-1" (id=1) for /servers.
+    // Passing server_id="web-1" should resolve to "1" and then list sites.
+    const result = await executeToolWithCredentials(
+      "forge",
+      { resource: "sites", action: "list", server_id: "web-1" },
+      creds,
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("example.com");
+  });
+
+  it("should return error when non-numeric server_id resolves to multiple matches", async () => {
+    // "web" matches "web-1" partially — only 1 server in mock so this is a single match.
+    // Let's use a name with no match to test the zero-match error path.
+    const result = await executeToolWithCredentials(
+      "forge",
+      { resource: "sites", action: "list", server_id: "does-not-exist" },
+      creds,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("No server matching");
+  });
+
+  it("should skip auto-resolve for resolve action (passes server_id as-is)", async () => {
+    // resolve action skips auto-resolve — the handler itself manages resolution
+    const result = await executeToolWithCredentials(
+      "forge",
+      { resource: "servers", action: "resolve", query: "web" },
+      creds,
+    );
+    // Should succeed (the mock returns web-1 which matches "web")
+    expect(result.isError).toBeUndefined();
   });
 });

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -82,11 +82,14 @@ const SHARED_INPUT_PROPERTIES = {
     description: "Forge resource to operate on",
   },
   id: { type: "string" as const, description: "Resource ID (for get, delete, update actions)" },
-  server_id: { type: "string" as const, description: "Server ID (required for most resources)" },
-  site_id: {
+  server_id: {
     type: "string" as const,
     description:
-      "Site ID (required for site-level resources: deployments, env, certificates, etc.)",
+      "Server ID or name (names are auto-resolved via partial match, requires unique match)",
+  },
+  site_id: {
+    type: "string" as const,
+    description: "Site ID or domain name (auto-resolved via partial match, requires server_id)",
   },
   compact: {
     type: "boolean" as const,


### PR DESCRIPTION
Closes #75

Adds transparent name→ID resolution in `executeToolWithCredentials()` middleware. When `server_id` or `site_id` contains a non-numeric string, the system automatically resolves it to the matching server/site ID before routing to handlers.

- Single exact match: resolves silently
- Multiple matches: returns error listing candidates  
- No matches: returns descriptive error
- Skipped for `resolve` action (which handles its own name resolution)

Rebased onto main after #72 was merged.

---
Supersedes #77 (auto-closed when target branch was deleted).