### PR TITLE
Stream deploy logs to stdout in real time

### DIFF
--- a/packages/cli/src/commands/deployments/handlers.test.ts
+++ b/packages/cli/src/commands/deployments/handlers.test.ts
@@ -105,10 +105,16 @@ describe("deploymentsDeploy", () => {
     expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("succeeded"));
   });
 
-  it("should display deployment log after success", async () => {
+  it("should stream deployment log via onLog callback", async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
     const { deploySiteAndWait } = await import("@studiometa/forge-core");
-    vi.mocked(deploySiteAndWait).mockResolvedValue({
-      data: { status: "success", log: "Build succeeded.\nDone.", elapsed_ms: 5000 },
+    vi.mocked(deploySiteAndWait).mockImplementation(async (opts) => {
+      if (opts.onLog) {
+        opts.onLog("Build succeeded.\n");
+        opts.onLog("Done.\n");
+      }
+      return { data: { status: "success", log: "Build succeeded.\nDone.\n", elapsed_ms: 5000 } };
     });
 
     const ctx = createTestContext({
@@ -118,9 +124,8 @@ describe("deploymentsDeploy", () => {
     });
 
     await deploymentsDeploy(ctx);
-    expect(vi.mocked(console.log)).toHaveBeenCalledWith(
-      expect.stringContaining("Build succeeded."),
-    );
+    expect(stdoutSpy).toHaveBeenCalledWith("Build succeeded.\n");
+    expect(stdoutSpy).toHaveBeenCalledWith("Done.\n");
   });
 
   it("should display failed status when deployment fails", async () => {

--- a/packages/cli/src/commands/deployments/handlers.ts
+++ b/packages/cli/src/commands/deployments/handlers.ts
@@ -74,6 +74,9 @@ export async function deploymentsDeploy(ctx: CommandContext): Promise<void> {
         onProgress: ({ status, elapsed_ms }) => {
           process.stderr.write(`\rDeploying… ${status} (${(elapsed_ms / 1000).toFixed(1)}s)`);
         },
+        onLog: (chunk) => {
+          process.stdout.write(chunk);
+        },
       },
       execCtx,
     );
@@ -87,10 +90,6 @@ export async function deploymentsDeploy(ctx: CommandContext): Promise<void> {
       ctx.formatter.success(`Deployment succeeded for site ${site_id} (${elapsedSec}s).`);
     } else {
       ctx.formatter.success(`Deployment failed for site ${site_id} (${elapsedSec}s).`);
-    }
-
-    if (result.data.log) {
-      ctx.formatter.output(result.data.log);
     }
   }, ctx.formatter);
 }

--- a/packages/core/src/executors/deployments/deploy-and-wait.test.ts
+++ b/packages/core/src/executors/deployments/deploy-and-wait.test.ts
@@ -191,4 +191,168 @@ describe("deploySiteAndWait", () => {
     // If deployments fetch fails we default to 'failed'
     expect(result.data.status).toBe("failed");
   });
+
+  it("should stream log output incrementally via onLog callback", async () => {
+    const postMock = vi.fn(async () => undefined);
+
+    let pollCount = 0;
+    const getMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/deployment/log")) return "line1\nline2\nline3\n";
+      if (url.endsWith("/deployments")) {
+        return { deployments: [{ id: 42, status: "finished" }] };
+      }
+      if (url.includes("/deployments/42/output")) {
+        // Simulate incremental output growth
+        if (pollCount <= 1) return "line1\n";
+        return "line1\nline2\nline3\n";
+      }
+      // site poll
+      pollCount++;
+      return {
+        site: { id: 456, deployment_status: pollCount < 3 ? "deploying" : null },
+      };
+    });
+
+    const onLog = vi.fn();
+
+    const ctx = createTestExecutorContext({
+      client: { post: postMock, get: getMock } as never,
+    });
+
+    const promise = deploySiteAndWait(
+      { server_id: "123", site_id: "456", poll_interval_ms: 100, onLog },
+      ctx,
+    );
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // onLog should have been called with incremental chunks
+    expect(onLog).toHaveBeenCalled();
+
+    // Reconstruct streamed output
+    const streamed = onLog.mock.calls.map((c) => c[0]).join("");
+    // Should contain the full log content
+    expect(streamed).toContain("line1\n");
+    expect(streamed).toContain("line2\n");
+    expect(streamed).toContain("line3\n");
+  });
+
+  it("should not fetch deployment output when onLog is not provided", async () => {
+    const postMock = vi.fn(async () => undefined);
+
+    const getMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/deployment/log")) return "log content";
+      if (url.endsWith("/deployments")) return { deployments: [{ id: 42, status: "finished" }] };
+      return { site: { id: 456, deployment_status: null } };
+    });
+
+    const ctx = createTestExecutorContext({
+      client: { post: postMock, get: getMock } as never,
+    });
+
+    const promise = deploySiteAndWait(
+      { server_id: "123", site_id: "456", poll_interval_ms: 100 },
+      ctx,
+    );
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // Should never call the deployment output endpoint
+    const outputCalls = getMock.mock.calls.filter((c) => String(c[0]).includes("/output"));
+    expect(outputCalls).toHaveLength(0);
+  });
+
+  it("should handle deployment output fetch errors gracefully", async () => {
+    const postMock = vi.fn(async () => undefined);
+
+    const getMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/deployment/log")) return "final log";
+      if (url.includes("/deployments/42/output")) throw new Error("output not ready");
+      if (url.endsWith("/deployments")) return { deployments: [{ id: 42, status: "finished" }] };
+      return { site: { id: 456, deployment_status: null } };
+    });
+
+    const onLog = vi.fn();
+
+    const ctx = createTestExecutorContext({
+      client: { post: postMock, get: getMock } as never,
+    });
+
+    const promise = deploySiteAndWait(
+      { server_id: "123", site_id: "456", poll_interval_ms: 100, onLog },
+      ctx,
+    );
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // onLog should still be called with the final log content
+    expect(onLog).toHaveBeenCalledWith("final log");
+  });
+
+  it("should emit remaining log content from final log fetch", async () => {
+    const postMock = vi.fn(async () => undefined);
+
+    const getMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/deployment/log")) return "line1\nline2\nline3\n";
+      if (url.includes("/deployments/42/output")) return "line1\n";
+      if (url.endsWith("/deployments")) return { deployments: [{ id: 42, status: "finished" }] };
+      return { site: { id: 456, deployment_status: null } };
+    });
+
+    const onLog = vi.fn();
+
+    const ctx = createTestExecutorContext({
+      client: { post: postMock, get: getMock } as never,
+    });
+
+    const promise = deploySiteAndWait(
+      { server_id: "123", site_id: "456", poll_interval_ms: 100, onLog },
+      ctx,
+    );
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // Should have emitted "line1\n" from output, then "line2\nline3\n" from final log
+    const streamed = onLog.mock.calls.map((c) => c[0]).join("");
+    expect(streamed).toBe("line1\nline2\nline3\n");
+  });
+
+  it("should handle deployments list failure when resolving deployment ID for onLog", async () => {
+    const postMock = vi.fn(async () => undefined);
+
+    let deploymentsCallCount = 0;
+    const getMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/deployment/log")) return "the log";
+      if (url.endsWith("/deployments")) {
+        deploymentsCallCount++;
+        // First call (to resolve deployment ID) fails, second call (to check status) succeeds
+        if (deploymentsCallCount === 1) throw new Error("not available");
+        return { deployments: [{ id: 1, status: "finished" }] };
+      }
+      return { site: { id: 456, deployment_status: null } };
+    });
+
+    const onLog = vi.fn();
+
+    const ctx = createTestExecutorContext({
+      client: { post: postMock, get: getMock } as never,
+    });
+
+    const promise = deploySiteAndWait(
+      { server_id: "123", site_id: "456", poll_interval_ms: 100, onLog },
+      ctx,
+    );
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    // Should still succeed, just without streaming
+    expect(result.data.status).toBe("success");
+    // onLog should still receive the final log content
+    expect(onLog).toHaveBeenCalledWith("the log");
+  });
 });

--- a/packages/core/src/executors/deployments/deploy-and-wait.ts
+++ b/packages/core/src/executors/deployments/deploy-and-wait.ts
@@ -5,28 +5,54 @@ import type { ExecutorContext, ExecutorResult } from "../../context.ts";
 import type { DeploySiteAndWaitOptions, DeployResult } from "./types.ts";
 
 /**
- * Trigger a deployment and wait for it to complete.
+ * Trigger a deployment and wait for it to complete, streaming logs in real time.
  *
  * 1. POSTs to the deploy endpoint.
- * 2. Polls GET /servers/{id}/sites/{site_id} every `poll_interval_ms` ms.
- * 3. When `deployment_status` becomes null the deploy is done.
- * 4. Fetches the deployment log.
- * 5. Checks the most recent deployment status to determine success/failure.
+ * 2. Fetches the latest deployment ID from the deployments list.
+ * 3. Polls GET /servers/{id}/sites/{site_id} every `poll_interval_ms` ms.
+ * 4. On each poll, fetches the deployment output and emits new lines via `onLog`.
+ * 5. When `deployment_status` becomes null the deploy is done.
+ * 6. Fetches the final deployment log.
+ * 7. Checks the most recent deployment status to determine success/failure.
  */
 export async function deploySiteAndWait(
   options: DeploySiteAndWaitOptions,
   ctx: ExecutorContext,
 ): Promise<ExecutorResult<DeployResult>> {
-  const { server_id, site_id, poll_interval_ms = 3000, timeout_ms = 600_000, onProgress } = options;
+  const {
+    server_id,
+    site_id,
+    poll_interval_ms = 3000,
+    timeout_ms = 600_000,
+    onProgress,
+    onLog,
+  } = options;
 
   const baseUrl = `/servers/${server_id}/sites/${site_id}`;
 
   // 1. Trigger deploy
   await ctx.client.post(`${baseUrl}/deployment/deploy`);
 
-  const startTime = Date.now();
+  // 2. Resolve the deployment ID for output streaming
+  let deploymentId: number | null = null;
+  if (onLog) {
+    try {
+      const deploymentsResponse = await ctx.client.get<DeploymentsResponse>(
+        `${baseUrl}/deployments`,
+      );
+      const deployments = deploymentsResponse.deployments;
+      if (deployments.length > 0) {
+        deploymentId = deployments[0]!.id;
+      }
+    } catch {
+      // If we can't get the deployment ID, we'll skip streaming
+    }
+  }
 
-  // 2. Poll until deployment_status is null (done)
+  const startTime = Date.now();
+  let logOffset = 0;
+
+  // 3. Poll until deployment_status is null (done)
   await new Promise<void>((resolve) => {
     const tick = async (): Promise<void> => {
       const elapsed_ms = Date.now() - startTime;
@@ -44,6 +70,21 @@ export async function deploySiteAndWait(
         onProgress({ status: currentStatus ?? "done", elapsed_ms });
       }
 
+      // 4. Stream deployment output incrementally
+      if (onLog && deploymentId !== null) {
+        try {
+          const output = await ctx.client.get<string>(
+            `${baseUrl}/deployments/${deploymentId}/output`,
+          );
+          if (output && output.length > logOffset) {
+            onLog(output.slice(logOffset));
+            logOffset = output.length;
+          }
+        } catch {
+          // Output may not be available yet; continue
+        }
+      }
+
       if (currentStatus === null) {
         resolve();
         return;
@@ -58,7 +99,7 @@ export async function deploySiteAndWait(
 
   const elapsed_ms = Date.now() - startTime;
 
-  // 3. Fetch deployment log
+  // 5. Final log fetch — emit any remaining output
   let log = "";
   try {
     log = await ctx.client.get<string>(`${baseUrl}/deployment/log`);
@@ -66,7 +107,11 @@ export async function deploySiteAndWait(
     // log may not be available; continue
   }
 
-  // 4. Determine success/failure from the most recent deployment
+  if (onLog && log.length > logOffset) {
+    onLog(log.slice(logOffset));
+  }
+
+  // 6. Determine success/failure from the most recent deployment
   let deployStatus: "success" | "failed" = "failed";
   try {
     const deploymentsResponse = await ctx.client.get<DeploymentsResponse>(`${baseUrl}/deployments`);
@@ -79,7 +124,7 @@ export async function deploySiteAndWait(
     // If we can't fetch deployments, keep 'failed'
   }
 
-  // 5. If we timed out, force 'failed'
+  // 7. If we timed out, force 'failed'
   if (elapsed_ms >= timeout_ms) {
     deployStatus = "failed";
   }

--- a/packages/core/src/executors/deployments/types.ts
+++ b/packages/core/src/executors/deployments/types.ts
@@ -64,6 +64,11 @@ export interface DeploySiteAndWaitOptions {
   timeout_ms?: number;
   /** Called on each poll iteration with current status and elapsed time. */
   onProgress?: (update: { status: string; elapsed_ms: number }) => void;
+  /**
+   * Called with new log lines as they appear during deployment.
+   * Only new content since the last call is provided (incremental).
+   */
+  onLog?: (chunk: string) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary

During `deploySiteAndWait`, deployment logs are now streamed to stdout in real time via polling instead of being displayed only after completion.

## Changes

### Core (`forge-core`)

- **`types.ts`**: Add `onLog` callback to `DeploySiteAndWaitOptions` — called incrementally with new log content as it appears
- **`deploy-and-wait.ts`**: After triggering the deploy, resolve the deployment ID from the deployments list, then on each poll tick fetch `/deployments/{id}/output` and emit only new content (offset-based). Any remaining content from the final `/deployment/log` fetch is also emitted.

### CLI (`forge-cli`)

- **`handlers.ts`**: Wire `onLog` to `process.stdout.write()` — logs stream live. Removed the post-deploy `formatter.output(result.data.log)` since content is already streamed.

### Tests

- 5 new test cases for `onLog` behavior: incremental streaming, graceful error handling, final log remainder, no output fetch when `onLog` absent, deployment ID resolution failure
- Updated CLI handler test to verify `stdout.write` calls via `onLog`
