### PR TITLE
Fix deploy command to exit non-zero on deployment failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **CLI**: Fix `deployments deploy` to exit non-zero and record audit status "error" when a deployment fails [[#119]]
+- **Core**: Externalize `pino` so the audit log writes to file instead of printing to the console [[#119]]
 
 [#119]: https://github.com/studiometa/forge-tools/pull/119
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **CLI**: Fix `deployments deploy` to exit non-zero and record audit status "error" when a deployment fails [[#119]]
+
+[#119]: https://github.com/studiometa/forge-tools/pull/119
+
 ## 0.4.3 - 2026.04.09
 
 ### Added

--- a/packages/cli/src/commands/deployments/handlers.test.ts
+++ b/packages/cli/src/commands/deployments/handlers.test.ts
@@ -227,6 +227,8 @@ describe("deploymentsDeploy", () => {
     await deploymentsDeploy(ctx);
     expect(stdoutSpy).toHaveBeenCalledWith("Step 1\n");
     expect(stdoutSpy).toHaveBeenCalledWith("Step 2\n");
+    // Separator newline so the final status message is not on the last log line.
+    expect(stdoutSpy).toHaveBeenLastCalledWith("\n");
   });
 
   it("should use onProgress when --stream flag is not set", async () => {

--- a/packages/cli/src/commands/deployments/handlers.test.ts
+++ b/packages/cli/src/commands/deployments/handlers.test.ts
@@ -127,7 +127,7 @@ describe("deploymentsDeploy", () => {
     );
   });
 
-  it("should display failed status when deployment fails", async () => {
+  it("should display failed status and exit non-zero when deployment fails", async () => {
     const { deploySiteAndWait } = await import("@studiometa/forge-core");
     vi.mocked(deploySiteAndWait).mockResolvedValue({
       data: { status: "failed", log: "Error: npm install failed.", elapsed_ms: 2000 },
@@ -140,7 +140,27 @@ describe("deploymentsDeploy", () => {
     });
 
     await deploymentsDeploy(ctx);
-    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("failed"));
+    expect(vi.mocked(console.error)).toHaveBeenCalledWith(expect.stringContaining("failed"));
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("should output the log before failing when deployment fails without streaming", async () => {
+    const { deploySiteAndWait } = await import("@studiometa/forge-core");
+    vi.mocked(deploySiteAndWait).mockResolvedValue({
+      data: { status: "failed", log: "Error: npm install failed.", elapsed_ms: 2000 },
+    });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human", server: "10", site: "100" },
+    });
+
+    await deploymentsDeploy(ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(
+      expect.stringContaining("Error: npm install failed."),
+    );
+    expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
   it("should call onProgress during polling", async () => {

--- a/packages/cli/src/commands/deployments/handlers.ts
+++ b/packages/cli/src/commands/deployments/handlers.ts
@@ -3,6 +3,7 @@ import { listDeployments, deploySiteAndWait } from "@studiometa/forge-core";
 import type { CommandContext } from "../../context.ts";
 
 import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+import { ApiError } from "../../errors.ts";
 import { resolveServerId, resolveSiteId } from "../../utils/resolve.ts";
 
 export async function deploymentsList(ctx: CommandContext): Promise<void> {
@@ -94,15 +95,17 @@ export async function deploymentsDeploy(ctx: CommandContext): Promise<void> {
 
     const elapsedSec = (result.data.elapsed_ms / 1000).toFixed(1);
 
+    // Output full log if we didn't stream it (needed for both success and failure).
+    if (!streamLogs && result.data.log) {
+      ctx.formatter.output(result.data.log);
+    }
+
     if (result.data.status === "success") {
       ctx.formatter.success(`Deployment succeeded for site ${site_id} (${elapsedSec}s).`);
     } else {
-      ctx.formatter.error(`Deployment failed for site ${site_id} (${elapsedSec}s).`);
-    }
-
-    // Only output full log if we didn't stream it
-    if (!streamLogs && result.data.log) {
-      ctx.formatter.output(result.data.log);
+      // Throw so the failure propagates to the exit code (non-zero) and the audit log
+      // records status "error" instead of "success".
+      throw new ApiError(`Deployment failed for site ${site_id} (${elapsedSec}s).`);
     }
   }, ctx.formatter);
 }

--- a/packages/cli/src/commands/deployments/handlers.ts
+++ b/packages/cli/src/commands/deployments/handlers.ts
@@ -88,8 +88,11 @@ export async function deploymentsDeploy(ctx: CommandContext): Promise<void> {
       execCtx,
     );
 
-    // Clear the progress line (only needed in non-stream mode)
-    if (!streamLogs) {
+    // Separate the final status message from preceding output: in stream mode the
+    // last log chunk has no trailing newline, otherwise clear the progress line.
+    if (streamLogs) {
+      process.stdout.write("\n");
+    } else {
       process.stderr.write("\n");
     }
 

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -5,7 +5,10 @@ import { createBuildConfig, createTestConfig } from "../../vite.config.base.ts";
 export default defineConfig({
   build: createBuildConfig({
     entry: { index: "./src/index.ts" },
-    external: [/^@studiometa\/forge-api/],
+    // Keep pino external so Node resolves its real (node) build at runtime.
+    // Bundling it makes Vite pick pino's "browser" build, which logs to the
+    // console instead of the audit file.
+    external: [/^@studiometa\/forge-api/, "pino"],
   }),
   test: createTestConfig({
     name: "core",


### PR DESCRIPTION
## Problem

`forge deployments deploy` (with or without `--stream`) always exited `0` and recorded `status: "success"` in the audit log, even when the deployment failed on the server (e.g. a deploy script exiting `1`).

## Root cause

The failure was detected correctly — `deploySiteAndWait()` returns `status: "failed"` and the handler printed `✗ Deployment failed …` — but the handler then **returned normally instead of throwing**. As a result:

- The `command-router` write wrapper never hit its `catch`, so it logged `status: "success"` to the audit log.
- Nothing propagated to `runCommand` → `handleError`, so the process exited with the default code `0`.

Both symptoms stem from the same missing throw. (Note: the audit log's `status` is control-flow-derived — "did the handler throw" — and is independent of the deployment's own `result.data.status`.)

## Fix

Throw an error on non-success in the deploy handler. This routes through the existing machinery:

- `command-router` catch → audit log records `status: "error"`
- re-throw → `runCommand` → `handleError` → `process.exit(1)`

The deployment log is now emitted **before** the throw (in non-stream mode) so failure output is still shown. No changes needed in `command-router` or `deploy-and-wait` — they already do the right thing once the handler stops swallowing the failure.

## Tests

- Updated the failing-deploy test to assert `process.exit(1)` and that the message goes to stderr.
- Added a test asserting the log is output before failing in non-stream mode.
- Full suite: 1879 passing; lint, format, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)