### PR TITLE
Pin GitHub Actions to commit SHAs and harden Renovate config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "npm"
@@ -32,10 +32,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "npm"
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: |
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "npm"
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: packages/
@@ -87,10 +87,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "npm"
@@ -99,7 +99,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: packages/
@@ -108,7 +108,7 @@ jobs:
         run: npm run test:ci
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
           name: codecov-umbrella
 
       - name: Upload test results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -140,7 +140,7 @@ jobs:
           done
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}
         with:
           name: coverage
@@ -157,7 +157,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Semgrep
         run: >

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "npm"
@@ -41,10 +41,10 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "npm"
@@ -105,7 +105,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           tag: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,10 +14,10 @@ jobs:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "npm"
@@ -34,7 +34,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Semgrep
         run: >
@@ -52,7 +52,7 @@ jobs:
           .
 
       - name: Upload results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: semgrep-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI**: Fix `deployments deploy` to exit non-zero and record audit status "error" when a deployment fails [[#119]]
 - **Core**: Externalize `pino` so the audit log writes to file instead of printing to the console [[#119]]
 
+### Security
+
+- **CI**: Pin GitHub Actions to commit SHAs and set a 7-day Renovate `minimumReleaseAge` to clear the Semgrep scan [[#120]]
+
 [#119]: https://github.com/studiometa/forge-tools/pull/119
+[#120]: https://github.com/studiometa/forge-tools/pull/120
 
 ## 0.4.3 - 2026.04.09
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,12 @@
   "extends": [
     "config:recommended",
     "security:openssf-scorecard",
+    "helpers:pinGitHubActionDigests",
     ":dependencyDashboard",
     ":semanticCommits",
     ":separateMajorReleases"
   ],
+  "minimumReleaseAge": "7 days",
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "schedule": ["before 9am on monday"],
@@ -20,13 +22,15 @@
       "description": "Group dev dependencies (minor/patch)",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "dev dependencies (non-major)"
+      "groupName": "dev dependencies (non-major)",
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Group production dependencies (patch only)",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"],
-      "groupName": "production dependencies (patch)"
+      "groupName": "production dependencies (patch)",
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Group GitHub Actions updates",
@@ -37,6 +41,7 @@
       "description": "Automerge patch updates for dev dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "7 days",
       "automerge": true,
       "automergeType": "pr"
     },
@@ -45,6 +50,7 @@
       "matchCategories": ["security"],
       "labels": ["security", "priority:high"],
       "schedule": ["at any time"],
+      "minimumReleaseAge": "7 days",
       "automerge": true,
       "automergeType": "pr"
     }


### PR DESCRIPTION
## Problem

The Semgrep Security Scan job was failing with 27 findings — all in CI configuration, none in application code:

- **24×** `github-actions-mutable-action-tag` in `ci.yml`, `publish.yml`, `security.yml` — workflow steps referenced mutable tags (`@v4`, `@v5`, `@v1`). A mutable tag can be silently repointed by the action owner, which was the vector in the `tj-actions/changed-files` compromise.
- **3×** `renovate-missing-minimum-release-age` in `renovate.json` — no cooldown before proposing/auto-merging newly published versions.

These pre-existed on `main` (not introduced by any recent PR).

## Fix

- **Pin all 24 `uses:` to full 40-char commit SHAs** with `# vX` version comments. Pinned the *current* major of each action (no version bumps — those are left to Renovate so they get tested independently):
  - `actions/checkout@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`, `codecov/codecov-action@v5`, `ncipollo/release-action@v1`
- **Add `helpers:pinGitHubActionDigests`** to Renovate's `extends` so it keeps the pinned digests updated automatically (pinning and Renovate are complementary, not in conflict).
- **Set `minimumReleaseAge: "7 days"`** globally and within each package rule. The Semgrep rule (`p/owasp-top-ten`) requires ≥ 7 days, so all cooldowns — including security updates — are set to 7 days.

## Verification

Ran the exact CI Semgrep command locally via Docker: **0 findings** (down from 27), exit 0. No application code changed.