### PR TITLE
Add `forge ssh` command to open SSH sessions to servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **CLI**: Add `forge ssh <server>` command to open an interactive SSH session, with `--user` (default: forge), `--private`, `--port`, remote command, and `--dry-run` [[#121], [8f142cb]]
+
+[#121]: https://github.com/studiometa/forge-tools/pull/121
+[8f142cb]: https://github.com/studiometa/forge-tools/commit/8f142cb
+
 ## 0.4.4 - 2026.07.01
 
 ### Fixed

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -59,6 +59,7 @@ forge <command> [subcommand] [options]
 | `nginx-templates` |         | List, get, create, update, delete Nginx templates    |
 | `certificates`    | `certs` | List, get, activate SSL certificates for a site      |
 | `firewall-rules`  | `fw`    | List, get firewall rules on a server                 |
+| `ssh`             |         | Open an SSH session to a server                      |
 | `ssh-keys`        |         | List, get SSH keys on a server                       |
 | `security-rules`  |         | List, get, create, delete security rules for a site  |
 | `redirect-rules`  |         | List, get, create, delete redirect rules for a site  |
@@ -180,6 +181,19 @@ forge certificates activate <cert_id> --server <id> --site <id> # Activate a cer
 forge firewall-rules list --server <id>                 # List firewall rules
 forge firewall-rules get <rule_id> --server <id>        # Get rule details
 ```
+
+### `ssh` — Open an SSH session to a server
+
+```bash
+forge ssh <server>                              # Interactive session (forge@<ip>)
+forge ssh <server> --user deploy                # Connect as a custom user
+forge ssh <server> --private                    # Connect over the private IP
+forge ssh <server> --port 2222                  # Override the SSH port
+forge ssh <server> uptime                       # Run a remote command, then exit
+forge ssh <server> --dry-run                    # Print the ssh command instead
+```
+
+Requires your local SSH key to be authorized on the server; this command launches `ssh`, it does not upload keys.
 
 ### `ssh-keys` — Manage SSH keys
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -38,6 +38,7 @@ import {
 } from "./commands/security-rules/index.ts";
 import { handleServersCommand, showServersHelp } from "./commands/servers/index.ts";
 import { handleSitesCommand, showSitesHelp } from "./commands/sites/index.ts";
+import { handleSshCommand, showSshHelp } from "./commands/ssh/index.ts";
 import { handleSshKeysCommand, showSshKeysHelp } from "./commands/ssh-keys/index.ts";
 import { handleUserCommand, showUserHelp } from "./commands/user/index.ts";
 import { colors, setColorEnabled } from "./utils/colors.ts";
@@ -103,6 +104,9 @@ ${colors.bold("COMMANDS:")}
   firewall-rules, fw  Manage firewall rules
     list, ls            List firewall rules (requires --server)
     get <id>            Get firewall rule details (requires --server)
+
+  ssh <server>        Open an SSH session to a server
+                        --user <name> (default: forge), --private, --port <n>
 
   ssh-keys            Manage SSH keys
     list, ls            List SSH keys (requires --server)
@@ -324,6 +328,14 @@ async function main(): Promise<void> {
           process.exit(0);
         }
         await handleFirewallRulesCommand(subcommand ?? "list", positional, options);
+        break;
+
+      case "ssh":
+        if (wantsHelp) {
+          showSshHelp();
+          process.exit(0);
+        }
+        await handleSshCommand(subcommand, positional, options);
         break;
 
       case "ssh-keys":

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -18,7 +18,7 @@ _forge_completions() {
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
   # Main commands
-  commands="config servers s sites deployments d databases db database-users daemons env nginx certificates certs firewall-rules fw ssh-keys backups commands scheduled-jobs user monitors nginx-templates security-rules redirect-rules recipes completion help"
+  commands="config servers s sites deployments d databases db database-users daemons env nginx certificates certs firewall-rules fw ssh ssh-keys backups commands scheduled-jobs user monitors nginx-templates security-rules redirect-rules recipes completion help"
 
   # Subcommands for each command
   local config_cmds="set get delete"
@@ -45,7 +45,7 @@ _forge_completions() {
   local completion_cmds="bash zsh fish"
 
   # Global options
-  options="--token --server --site -f --format --no-color -h --help -v --version --name --command --content --from --to --provider --frequency --type --operator --threshold --minutes --key --port --ip-address --user --script --servers --domain --password --credential-id --region --size --project-type --directory"
+  options="--token --server --site -f --format --no-color -h --help -v --version --name --command --content --from --to --provider --frequency --type --operator --threshold --minutes --key --port --ip-address --user --private --dry-run --script --servers --domain --password --credential-id --region --size --project-type --directory"
 
   # Format options
   local formats="json human table"
@@ -183,6 +183,7 @@ _forge() {
         'certs:Manage SSL certificates (alias)'
         'firewall-rules:Manage firewall rules'
         'fw:Manage firewall rules (alias)'
+        'ssh:Open an SSH session to a server'
         'ssh-keys:Manage SSH keys'
         'backups:Manage backup configurations'
         'commands:Manage site commands'
@@ -473,6 +474,7 @@ complete -c forge -f -n "__fish_use_subcommand" -a "certificates" -d "Manage SSL
 complete -c forge -f -n "__fish_use_subcommand" -a "certs" -d "Manage SSL certificates (alias)"
 complete -c forge -f -n "__fish_use_subcommand" -a "firewall-rules" -d "Manage firewall rules"
 complete -c forge -f -n "__fish_use_subcommand" -a "fw" -d "Manage firewall rules (alias)"
+complete -c forge -f -n "__fish_use_subcommand" -a "ssh" -d "Open an SSH session to a server"
 complete -c forge -f -n "__fish_use_subcommand" -a "ssh-keys" -d "Manage SSH keys"
 complete -c forge -f -n "__fish_use_subcommand" -a "backups" -d "Manage backup configurations"
 complete -c forge -f -n "__fish_use_subcommand" -a "commands" -d "Manage site commands"

--- a/packages/cli/src/commands/ssh/command.test.ts
+++ b/packages/cli/src/commands/ssh/command.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleSshCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  sshConnect: vi.fn().mockResolvedValue(),
+}));
+
+const fakeCtx = { formatter: {}, options: {} };
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn(() => fakeCtx),
+}));
+
+describe("handleSshCommand", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a context and delegates to sshConnect", async () => {
+    const { sshConnect } = await import("./handlers.ts");
+    const { createContext } = await import("../../context.ts");
+
+    await handleSshCommand("my-server", ["uptime"], { format: "human" });
+
+    expect(createContext).toHaveBeenCalledWith({ format: "human" });
+    expect(sshConnect).toHaveBeenCalledWith("my-server", ["uptime"], fakeCtx);
+  });
+
+  it("passes an undefined server through", async () => {
+    const { sshConnect } = await import("./handlers.ts");
+    await handleSshCommand(undefined, [], {});
+    expect(sshConnect).toHaveBeenCalledWith(undefined, [], fakeCtx);
+  });
+});

--- a/packages/cli/src/commands/ssh/command.ts
+++ b/packages/cli/src/commands/ssh/command.ts
@@ -1,0 +1,19 @@
+import type { CommandOptions } from "../../context.ts";
+
+import { createContext } from "../../context.ts";
+import { sshConnect } from "./handlers.ts";
+
+/**
+ * Route the top-level `forge ssh` command.
+ *
+ * Unlike resource commands there is no sub-action: the first positional is the
+ * server, and any remaining positionals form an optional remote command.
+ */
+export async function handleSshCommand(
+  server: string | undefined,
+  remote: string[],
+  options: CommandOptions,
+): Promise<void> {
+  const ctx = createContext(options);
+  await sshConnect(server, remote, ctx);
+}

--- a/packages/cli/src/commands/ssh/handlers.test.ts
+++ b/packages/cli/src/commands/ssh/handlers.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { ServerAttributes } from "@studiometa/forge-api";
+
+import { createTestContext } from "../../context.ts";
+import { sshConnect } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  getServer: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+const auditLog = vi.fn();
+vi.mock("../../audit.ts", () => ({
+  getCliAuditLogger: () => ({ log: auditLog }),
+}));
+
+const mockServer: ServerAttributes = {
+  id: 123,
+  credential_id: 0,
+  name: "my-server",
+  type: "app",
+  provider: "ocean2",
+  identifier: null,
+  size: "01",
+  region: "nyc3",
+  ubuntu_version: "22.04",
+  db_status: null,
+  redis_status: null,
+  php_version: "php83",
+  php_cli_version: "php83",
+  database_type: "mysql8",
+  ip_address: "1.2.3.4",
+  ssh_port: 22,
+  private_ip_address: "10.0.0.1",
+  local_public_key: null,
+  opcache_status: null,
+  connection_status: "connected",
+  timezone: "UTC",
+  is_ready: true,
+  revoked: false,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+} as ServerAttributes;
+
+function ctxWith(options: Record<string, string | boolean>) {
+  return createTestContext({
+    token: "test",
+    mockClient: {} as never,
+    options: { "no-color": true, ...options },
+  });
+}
+
+describe("sshConnect", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    auditLog.mockClear();
+
+    const { getServer } = await import("@studiometa/forge-core");
+    vi.mocked(getServer).mockResolvedValue({ data: mockServer });
+
+    const { spawnSync } = await import("node:child_process");
+    vi.mocked(spawnSync).mockReturnValue({ status: 0 } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exits with a validation error when no server is given", async () => {
+    await sshConnect(undefined, [], ctxWith({ format: "json" })).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("prints the resolved command as JSON without connecting", async () => {
+    const { spawnSync } = await import("node:child_process");
+    await sshConnect("123", [], ctxWith({ format: "json" }));
+
+    expect(spawnSync).not.toHaveBeenCalled();
+    const payload = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(payload.command).toBe("ssh forge@1.2.3.4 -p 22");
+    expect(payload.user).toBe("forge");
+  });
+
+  it("prints the command in --dry-run mode", async () => {
+    const { spawnSync } = await import("node:child_process");
+    await sshConnect("123", [], ctxWith({ format: "human", "dry-run": true }));
+
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith("ssh forge@1.2.3.4 -p 22");
+  });
+
+  it("spawns ssh interactively with the resolved args", async () => {
+    const { spawnSync } = await import("node:child_process");
+    await sshConnect("123", [], ctxWith({ format: "human", user: "deploy", private: true }));
+
+    expect(spawnSync).toHaveBeenCalledWith("ssh", ["deploy@10.0.0.1", "-p", "22"], {
+      stdio: "inherit",
+    });
+    expect(auditLog).toHaveBeenCalledWith(expect.objectContaining({ status: "success" }));
+  });
+
+  it("appends a remote command", async () => {
+    const { spawnSync } = await import("node:child_process");
+    await sshConnect("123", ["uptime"], ctxWith({ format: "human" }));
+
+    expect(spawnSync).toHaveBeenCalledWith("ssh", ["forge@1.2.3.4", "-p", "22", "uptime"], {
+      stdio: "inherit",
+    });
+  });
+
+  it("propagates a non-zero ssh exit code", async () => {
+    const { spawnSync } = await import("node:child_process");
+    vi.mocked(spawnSync).mockReturnValue({ status: 42 } as never);
+
+    await sshConnect("123", [], ctxWith({ format: "human" }));
+    expect(processExitSpy).toHaveBeenCalledWith(42);
+  });
+
+  it("logs an error and reports when ssh cannot be spawned", async () => {
+    const { spawnSync } = await import("node:child_process");
+    vi.mocked(spawnSync).mockReturnValue({ error: new Error("spawn ssh ENOENT") } as never);
+
+    await sshConnect("123", [], ctxWith({ format: "human" }));
+
+    expect(auditLog).toHaveBeenCalledWith(expect.objectContaining({ status: "error" }));
+    // runCommand catches the rethrown error and exits with the general error code.
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/ssh/handlers.ts
+++ b/packages/cli/src/commands/ssh/handlers.ts
@@ -1,0 +1,95 @@
+/**
+ * CLI handler for `forge ssh` — open an interactive SSH session to a server.
+ *
+ * Resolves the server, reads its connection details from the API, then hands
+ * off to the local `ssh` binary with an inherited stdio (interactive) session.
+ */
+
+import { spawnSync } from "node:child_process";
+
+import { getServer } from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+import { getCliAuditLogger } from "../../audit.ts";
+import { resolveServerId } from "../../utils/resolve.ts";
+import { buildSshArgs, resolveSshTarget } from "./ssh-target.ts";
+
+/**
+ * Connect to a server over SSH.
+ *
+ * @param server - Server ID or name (resolved via {@link resolveServerId}).
+ * @param remote - Optional remote command to run instead of an interactive shell.
+ * @param ctx - CLI command context.
+ */
+export async function sshConnect(
+  server: string | undefined,
+  remote: string[],
+  ctx: CommandContext,
+): Promise<void> {
+  if (!server) {
+    exitWithValidationError("server", "forge ssh <server> [command...]", ctx.formatter);
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const server_id = await resolveServerId(server, execCtx);
+    const { data } = await getServer({ server_id }, execCtx);
+
+    const target = resolveSshTarget(data, {
+      user: typeof ctx.options.user === "string" ? ctx.options.user : undefined,
+      private: ctx.options.private === true,
+      port: typeof ctx.options.port === "string" ? ctx.options.port : undefined,
+    });
+
+    const sshArgs = buildSshArgs(target, remote);
+    const printable = `ssh ${sshArgs.join(" ")}`;
+
+    // Script-safe modes: print the resolved command instead of opening a session.
+    if (ctx.formatter.isJson()) {
+      ctx.formatter.output({ command: printable, ...target, args: sshArgs });
+      return;
+    }
+    if (ctx.options["dry-run"] === true) {
+      console.log(printable);
+      return;
+    }
+
+    // Sanitized args for the audit log (never record the token).
+    const auditArgs = {
+      server: server_id,
+      user: target.user,
+      host: target.host,
+      port: target.port,
+    };
+
+    try {
+      const child = spawnSync("ssh", sshArgs, { stdio: "inherit" });
+      if (child.error) {
+        throw child.error;
+      }
+      getCliAuditLogger().log({
+        source: "cli",
+        resource: "ssh",
+        action: "connect",
+        args: auditArgs,
+        status: "success",
+      });
+      if (typeof child.status === "number" && child.status !== 0) {
+        process.exit(child.status);
+      }
+    } catch (err) {
+      getCliAuditLogger().log({
+        source: "cli",
+        resource: "ssh",
+        action: "connect",
+        args: auditArgs,
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/ssh/help.test.ts
+++ b/packages/cli/src/commands/ssh/help.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showSshHelp } from "./help.ts";
+
+describe("showSshHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("documents the command, the --user flag and the default user", () => {
+    showSshHelp();
+    const output = consoleLogSpy.mock.calls[0][0] as string;
+    expect(output).toContain("forge ssh");
+    expect(output).toContain("--user");
+    expect(output).toContain("default: forge");
+    expect(output).toContain("--private");
+  });
+});

--- a/packages/cli/src/commands/ssh/help.ts
+++ b/packages/cli/src/commands/ssh/help.ts
@@ -1,0 +1,42 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showSshHelp(): void {
+  console.log(`
+${colors.bold("forge ssh")} - Open an SSH session to a server
+
+${colors.bold("USAGE:")}
+  forge ssh <server> [command...] [options]
+
+${colors.bold("ARGUMENTS:")}
+  <server>            Server ID or name (required)
+  [command...]        Optional remote command to run, then exit
+
+${colors.bold("OPTIONS:")}
+  --user <name>       SSH user (default: forge)
+  --private           Connect over the private IP address
+  --port <n>          Override the server's SSH port
+  --dry-run           Print the ssh command instead of connecting
+  -f, --format json   Print the resolved connection details as JSON
+  -h, --help          Show this help
+
+${colors.bold("EXAMPLES:")}
+  # Interactive session (connects as forge@<ip>)
+  forge ssh my-server
+
+  # Connect as a custom user
+  forge ssh my-server --user deploy
+
+  # Use the private network
+  forge ssh my-server --private
+
+  # Run a one-off remote command
+  forge ssh my-server uptime
+
+  # Just show the command that would run
+  forge ssh my-server --dry-run
+
+${colors.bold("NOTES:")}
+  Requires your local SSH key to be authorized on the server; this command
+  launches ssh, it does not upload keys.
+`);
+}

--- a/packages/cli/src/commands/ssh/index.ts
+++ b/packages/cli/src/commands/ssh/index.ts
@@ -1,0 +1,2 @@
+export { handleSshCommand } from "./command.ts";
+export { showSshHelp } from "./help.ts";

--- a/packages/cli/src/commands/ssh/ssh-target.test.ts
+++ b/packages/cli/src/commands/ssh/ssh-target.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+
+import type { ServerAttributes } from "@studiometa/forge-api";
+
+import { ValidationError } from "../../errors.ts";
+import { DEFAULT_SSH_USER, buildSshArgs, resolveSshTarget } from "./ssh-target.ts";
+
+const baseServer: ServerAttributes = {
+  id: 1,
+  credential_id: 0,
+  name: "my-server",
+  type: "app",
+  provider: "ocean2",
+  identifier: null,
+  size: "01",
+  region: "nyc3",
+  ubuntu_version: "22.04",
+  db_status: null,
+  redis_status: null,
+  php_version: "php83",
+  php_cli_version: "php83",
+  database_type: "mysql8",
+  ip_address: "1.2.3.4",
+  ssh_port: 22,
+  private_ip_address: "10.0.0.1",
+  local_public_key: null,
+  opcache_status: null,
+  connection_status: "connected",
+  timezone: "UTC",
+  is_ready: true,
+  revoked: false,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+} as ServerAttributes;
+
+describe("resolveSshTarget", () => {
+  it("defaults to the forge user, public IP and server ssh port", () => {
+    expect(resolveSshTarget(baseServer)).toEqual({
+      user: DEFAULT_SSH_USER,
+      host: "1.2.3.4",
+      port: 22,
+    });
+  });
+
+  it("honors a custom user (trimmed)", () => {
+    expect(resolveSshTarget(baseServer, { user: "  deploy  " }).user).toBe("deploy");
+  });
+
+  it("falls back to the default user when the override is blank", () => {
+    expect(resolveSshTarget(baseServer, { user: "   " }).user).toBe(DEFAULT_SSH_USER);
+  });
+
+  it("uses the private IP with --private", () => {
+    expect(resolveSshTarget(baseServer, { private: true }).host).toBe("10.0.0.1");
+  });
+
+  it("overrides the port when a valid one is given", () => {
+    expect(resolveSshTarget(baseServer, { port: "2222" }).port).toBe(2222);
+  });
+
+  it("throws when the public IP is not available (provisioning)", () => {
+    const server = { ...baseServer, ip_address: null, is_ready: false } as ServerAttributes;
+    expect(() => resolveSshTarget(server)).toThrow(ValidationError);
+    try {
+      resolveSshTarget(server);
+    } catch (err) {
+      expect((err as ValidationError).hints?.some((h) => h.includes("provisioning"))).toBe(true);
+      expect((err as ValidationError).hints?.some((h) => h.includes("--private"))).toBe(true);
+    }
+  });
+
+  it("throws when the private IP is not available", () => {
+    const server = { ...baseServer, private_ip_address: null } as ServerAttributes;
+    expect(() => resolveSshTarget(server, { private: true })).toThrow(/private IP address/);
+  });
+
+  it.each(["0", "70000", "abc", "22.5"])("rejects invalid port %s", (port) => {
+    expect(() => resolveSshTarget(baseServer, { port })).toThrow(/Invalid SSH port/);
+  });
+});
+
+describe("buildSshArgs", () => {
+  it("builds connection args without a remote command", () => {
+    expect(buildSshArgs({ user: "forge", host: "1.2.3.4", port: 22 })).toEqual([
+      "forge@1.2.3.4",
+      "-p",
+      "22",
+    ]);
+  });
+
+  it("appends the remote command", () => {
+    expect(buildSshArgs({ user: "deploy", host: "1.2.3.4", port: 2222 }, ["uptime"])).toEqual([
+      "deploy@1.2.3.4",
+      "-p",
+      "2222",
+      "uptime",
+    ]);
+  });
+});

--- a/packages/cli/src/commands/ssh/ssh-target.ts
+++ b/packages/cli/src/commands/ssh/ssh-target.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure helpers for resolving SSH connection details from a Forge server.
+ *
+ * Kept free of side effects so the resolution logic is fully unit-testable
+ * without spawning a real `ssh` process.
+ */
+
+import type { ServerAttributes } from "@studiometa/forge-api";
+
+import { ValidationError } from "../../errors.ts";
+
+/** Forge's conventional default provisioning user. */
+export const DEFAULT_SSH_USER = "forge";
+
+export interface SshTargetOptions {
+  /** SSH user (defaults to {@link DEFAULT_SSH_USER}). */
+  user?: string;
+  /** Connect over the private network (`private_ip_address`) instead of the public IP. */
+  private?: boolean;
+  /** Override the server's `ssh_port` (string as parsed from the CLI). */
+  port?: string;
+}
+
+export interface SshTarget {
+  user: string;
+  host: string;
+  port: number;
+}
+
+/**
+ * Resolve the concrete user/host/port to connect to.
+ *
+ * @throws {ValidationError} when the selected IP is not available yet, or the port override is invalid.
+ */
+export function resolveSshTarget(
+  server: ServerAttributes,
+  options: SshTargetOptions = {},
+): SshTarget {
+  const user = options.user?.trim() || DEFAULT_SSH_USER;
+
+  const host = options.private ? server.private_ip_address : server.ip_address;
+  if (!host) {
+    const which = options.private ? "private IP address" : "IP address";
+    const hints = [
+      server.is_ready
+        ? "The server is ready but no address is available — check the Forge dashboard."
+        : "The server is still provisioning. Wait until it is ready, then try again.",
+      options.private ? undefined : "Use --private to connect over the private network.",
+    ].filter((hint): hint is string => Boolean(hint));
+
+    throw new ValidationError(`Server "${server.name}" has no ${which} available`, "server", hints);
+  }
+
+  let port = server.ssh_port;
+  if (options.port !== undefined) {
+    const parsed = Number(options.port);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+      throw new ValidationError(`Invalid SSH port "${options.port}"`, "port", [
+        "Port must be an integer between 1 and 65535.",
+      ]);
+    }
+    port = parsed;
+  }
+
+  return { user, host, port };
+}
+
+/**
+ * Build the argument list passed to the `ssh` binary.
+ *
+ * Any {@link remoteCommand} is appended after the connection flags, so
+ * `forge ssh web uptime` runs `uptime` remotely and exits.
+ */
+export function buildSshArgs(target: SshTarget, remoteCommand: string[] = []): string[] {
+  const args = [`${target.user}@${target.host}`, "-p", String(target.port)];
+  if (remoteCommand.length > 0) {
+    args.push(...remoteCommand);
+  }
+  return args;
+}


### PR DESCRIPTION
## What

Adds a top-level `forge ssh <server>` command that opens an SSH session to a Forge server. The server is resolved by ID or name, its connection details are read from the API, and the command hands off to the local `ssh` binary for a real interactive session.

```bash
forge ssh my-server                 # interactive session as forge@<ip>
forge ssh my-server --user deploy    # custom user
forge ssh my-server --private        # connect over the private IP
forge ssh my-server --port 2222      # override the SSH port
forge ssh my-server uptime           # run a remote command, then exit
forge ssh my-server --dry-run        # print the ssh command instead of connecting
```

## Why

The CLI could manage registered SSH *keys* but had no way to actually connect to a server. This closes that gap, with a customizable user as the headline ask.

## Details

- **`--user`** defaults to `forge` (Forge's conventional provisioning user), since the server object has no `ssh_user` attribute. `--private` uses `private_ip_address`, `--port` overrides `ssh_port`.
- Connection resolution (`resolveSshTarget` / `buildSshArgs`) is a **pure, fully-tested helper**; it raises a clear `ValidationError` when the chosen IP is not available yet (e.g. the server is still provisioning).
- `--format json` and `--dry-run` print the resolved command instead of connecting — script-safe and testable.
- The connect action is recorded in the **audit log**.
- Shell completions (bash/zsh/fish) and the CLI README are updated.

## Notes

- Requires your local SSH key to be authorized on the server — the command launches `ssh`, it does not upload keys.
- Complex remote commands with flags (`ssh web ls -la`) are not supported due to the CLI arg parser; simple remote commands work.

## Testing

- 23 new colocated tests (`ssh-target`, `handlers`, `command`, `help`); full suite green (1902 passed).
- `typecheck`, `lint`, and `format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)