### PR TITLE
Add services resource to list and restart server services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **CLI**: Add `forge deployments logs [id]` and `forge daemons logs <id>` commands to view deployment and daemon log output [[#124], [2f703f6]]
+- **Core/SDK/MCP/CLI**: Add a server-scoped `services` resource to list and restart services (nginx, php, mysql, postgres, redis, supervisor); restart maps to the API `reboot` action and php requires a version [[#125]]
 
 [#124]: https://github.com/studiometa/forge-tools/pull/124
+[#125]: https://github.com/studiometa/forge-tools/pull/125
 [2f703f6]: https://github.com/studiometa/forge-tools/commit/2f703f6
 
 ## 0.4.5 - 2026.07.20

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -37,6 +37,7 @@ import {
   showSecurityRulesHelp,
 } from "./commands/security-rules/index.ts";
 import { handleServersCommand, showServersHelp } from "./commands/servers/index.ts";
+import { handleServicesCommand, showServicesHelp } from "./commands/services/index.ts";
 import { handleSitesCommand, showSitesHelp } from "./commands/sites/index.ts";
 import { handleSshCommand, showSshHelp } from "./commands/ssh/index.ts";
 import { handleSshKeysCommand, showSshKeysHelp } from "./commands/ssh-keys/index.ts";
@@ -128,6 +129,10 @@ ${colors.bold("COMMANDS:")}
     get <id>            Get scheduled job details (requires --server)
     create              Create a scheduled job (requires --server --command)
     delete <id>         Delete a scheduled job (requires --server)
+
+  services            List and restart server services
+    list, ls            List services on a server (forge services list <server>)
+    restart <service>   Restart a service (forge services restart <server> <service>)
 
   user                Display authenticated user profile
     get                 Get the authenticated user profile
@@ -221,7 +226,10 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  if (options.version || options.v) {
+  // Only treat a bare `--version`/`-v` flag as the version request. A
+  // `--version <value>` (e.g. `forge services restart 123 php --version php83`)
+  // carries a string value and must fall through to the command dispatch.
+  if (options.version === true || options.v === true) {
     console.log(VERSION);
     process.exit(0);
   }
@@ -368,6 +376,14 @@ async function main(): Promise<void> {
           process.exit(0);
         }
         await handleScheduledJobsCommand(subcommand ?? "list", positional, options);
+        break;
+
+      case "services":
+        if (wantsHelp) {
+          showServicesHelp(subcommand);
+          process.exit(0);
+        }
+        await handleServicesCommand(subcommand ?? "list", positional, options);
         break;
 
       case "user":

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -664,7 +664,6 @@ complete -c forge -l key -d "Key" -r
 complete -c forge -l port -d "Port" -r
 complete -c forge -l ip-address -d "IP address" -r
 complete -c forge -l user -d "User" -r
-complete -c forge -l service -d "Service name" -xa "nginx php mysql postgres redis supervisor"
 complete -c forge -l script -d "Script" -r
 complete -c forge -l servers -d "Servers" -r
 complete -c forge -l domain -d "Domain" -r

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -18,7 +18,7 @@ _forge_completions() {
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
   # Main commands
-  commands="config servers s sites deployments d databases db database-users daemons env nginx certificates certs firewall-rules fw ssh ssh-keys backups commands scheduled-jobs user monitors nginx-templates security-rules redirect-rules recipes completion help"
+  commands="config servers s sites deployments d databases db database-users daemons env nginx certificates certs firewall-rules fw ssh ssh-keys backups commands scheduled-jobs services user monitors nginx-templates security-rules redirect-rules recipes completion help"
 
   # Subcommands for each command
   local config_cmds="set get delete"
@@ -36,6 +36,7 @@ _forge_completions() {
   local backups_cmds="list ls get create delete"
   local commands_cmds="list ls get create"
   local scheduled_jobs_cmds="list ls get create delete"
+  local services_cmds="list ls restart"
   local user_cmds="get"
   local monitors_cmds="list ls get create delete"
   local nginx_templates_cmds="list ls get create update delete"
@@ -45,7 +46,7 @@ _forge_completions() {
   local completion_cmds="bash zsh fish"
 
   # Global options
-  options="--token --server --site -f --format --no-color -h --help -v --version --name --command --content --from --to --provider --frequency --type --operator --threshold --minutes --key --port --ip-address --user --private --dry-run --script --servers --domain --password --credential-id --region --size --project-type --directory"
+  options="--token --server --site -f --format --no-color -h --help -v --version --service --name --command --content --from --to --provider --frequency --type --operator --threshold --minutes --key --port --ip-address --user --private --dry-run --script --servers --domain --password --credential-id --region --size --project-type --directory"
 
   # Format options
   local formats="json human table"
@@ -103,6 +104,9 @@ _forge_completions() {
           ;;
         scheduled-jobs)
           COMPREPLY=( $(compgen -W "\${scheduled_jobs_cmds}" -- "\${cur}") )
+          ;;
+        services)
+          COMPREPLY=( $(compgen -W "\${services_cmds}" -- "\${cur}") )
           ;;
         user)
           COMPREPLY=( $(compgen -W "\${user_cmds}" -- "\${cur}") )
@@ -188,6 +192,7 @@ _forge() {
         'backups:Manage backup configurations'
         'commands:Manage site commands'
         'scheduled-jobs:Manage scheduled jobs'
+        'services:List and restart server services'
         'user:Display authenticated user profile'
         'monitors:Manage server monitors'
         'nginx-templates:Manage Nginx templates'
@@ -346,6 +351,15 @@ _forge() {
           )
           _describe 'scheduled-jobs command' scheduled_jobs_cmds
           ;;
+        services)
+          local -a services_cmds
+          services_cmds=(
+            'list:List services on a server'
+            'ls:List services on a server (alias)'
+            'restart:Restart a service'
+          )
+          _describe 'services command' services_cmds
+          ;;
         user)
           local -a user_cmds
           user_cmds=(
@@ -443,6 +457,7 @@ _forge() {
         '--port[Port]:port:' \\
         '--ip-address[IP address]:ip address:' \\
         '--user[User]:user:' \\
+        '--service[Service name]:service:(nginx php mysql postgres redis supervisor)' \\
         '--script[Script]:script:' \\
         '--servers[Servers]:servers:' \\
         '--domain[Domain]:domain:' \\
@@ -483,6 +498,7 @@ complete -c forge -f -n "__fish_use_subcommand" -a "ssh-keys" -d "Manage SSH key
 complete -c forge -f -n "__fish_use_subcommand" -a "backups" -d "Manage backup configurations"
 complete -c forge -f -n "__fish_use_subcommand" -a "commands" -d "Manage site commands"
 complete -c forge -f -n "__fish_use_subcommand" -a "scheduled-jobs" -d "Manage scheduled jobs"
+complete -c forge -f -n "__fish_use_subcommand" -a "services" -d "List and restart server services"
 complete -c forge -f -n "__fish_use_subcommand" -a "user" -d "Display authenticated user profile"
 complete -c forge -f -n "__fish_use_subcommand" -a "monitors" -d "Manage server monitors"
 complete -c forge -f -n "__fish_use_subcommand" -a "nginx-templates" -d "Manage Nginx templates"
@@ -578,6 +594,11 @@ complete -c forge -f -n "__fish_seen_subcommand_from scheduled-jobs" -a "get" -d
 complete -c forge -f -n "__fish_seen_subcommand_from scheduled-jobs" -a "create" -d "Create a scheduled job"
 complete -c forge -f -n "__fish_seen_subcommand_from scheduled-jobs" -a "delete" -d "Delete a scheduled job"
 
+# services subcommands
+complete -c forge -f -n "__fish_seen_subcommand_from services" -a "list" -d "List services on a server"
+complete -c forge -f -n "__fish_seen_subcommand_from services" -a "ls" -d "List services on a server (alias)"
+complete -c forge -f -n "__fish_seen_subcommand_from services" -a "restart" -d "Restart a service"
+
 # user subcommands
 complete -c forge -f -n "__fish_seen_subcommand_from user" -a "get" -d "Get the authenticated user profile"
 
@@ -644,6 +665,7 @@ complete -c forge -l key -d "Key" -r
 complete -c forge -l port -d "Port" -r
 complete -c forge -l ip-address -d "IP address" -r
 complete -c forge -l user -d "User" -r
+complete -c forge -l service -d "Service name" -xa "nginx php mysql postgres redis supervisor"
 complete -c forge -l script -d "Script" -r
 complete -c forge -l servers -d "Servers" -r
 complete -c forge -l domain -d "Domain" -r

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -46,7 +46,7 @@ _forge_completions() {
   local completion_cmds="bash zsh fish"
 
   # Global options
-  options="--token --server --site -f --format --no-color -h --help -v --version --service --name --command --content --from --to --provider --frequency --type --operator --threshold --minutes --key --port --ip-address --user --private --dry-run --script --servers --domain --password --credential-id --region --size --project-type --directory"
+  options="--token --server --site -f --format --no-color -h --help -v --version --name --command --content --from --to --provider --frequency --type --operator --threshold --minutes --key --port --ip-address --user --private --dry-run --script --servers --domain --password --credential-id --region --size --project-type --directory"
 
   # Format options
   local formats="json human table"
@@ -457,7 +457,6 @@ _forge() {
         '--port[Port]:port:' \\
         '--ip-address[IP address]:ip address:' \\
         '--user[User]:user:' \\
-        '--service[Service name]:service:(nginx php mysql postgres redis supervisor)' \\
         '--script[Script]:script:' \\
         '--servers[Servers]:servers:' \\
         '--domain[Domain]:domain:' \\

--- a/packages/cli/src/commands/services/command.test.ts
+++ b/packages/cli/src/commands/services/command.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handleServicesCommand } from "./command.ts";
+
+vi.mock("./handlers.ts", () => ({
+  servicesList: vi.fn().mockResolvedValue(),
+  servicesRestart: vi.fn().mockResolvedValue(),
+}));
+
+vi.mock("../../context.ts", () => ({
+  createContext: vi.fn().mockReturnValue({
+    options: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../output.ts", () => ({
+  OutputFormatter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.output = vi.fn();
+    this.error = vi.fn();
+  }),
+}));
+
+describe("handleServicesCommand routing", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should route list with args", async () => {
+    const h = await import("./handlers.ts");
+    await handleServicesCommand("list", ["10"], {});
+    expect(h.servicesList).toHaveBeenCalledWith(["10"], expect.anything());
+  });
+
+  it("should route ls to list", async () => {
+    const h = await import("./handlers.ts");
+    await handleServicesCommand("ls", ["10"], {});
+    expect(h.servicesList).toHaveBeenCalledWith(["10"], expect.anything());
+  });
+
+  it("should route restart with args", async () => {
+    const h = await import("./handlers.ts");
+    await handleServicesCommand("restart", ["10", "nginx"], {});
+    expect(h.servicesRestart).toHaveBeenCalledWith(["10", "nginx"], expect.anything());
+  });
+
+  it("should exit for unknown subcommand", async () => {
+    await handleServicesCommand("unknown", [], {});
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/services/command.ts
+++ b/packages/cli/src/commands/services/command.ts
@@ -1,0 +1,12 @@
+import { createCommandRouter } from "../../utils/command-router.ts";
+import { servicesList, servicesRestart } from "./handlers.ts";
+
+export const handleServicesCommand = createCommandRouter({
+  resource: "services",
+  handlers: {
+    list: [servicesList, "args"],
+    ls: [servicesList, "args"],
+    restart: [servicesRestart, "args"],
+  },
+  writeSubcommands: ["restart"],
+});

--- a/packages/cli/src/commands/services/handlers.test.ts
+++ b/packages/cli/src/commands/services/handlers.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createTestContext } from "../../context.ts";
+import { servicesList, servicesRestart } from "./handlers.ts";
+
+vi.mock("@studiometa/forge-core", () => ({
+  listServices: vi.fn(),
+  restartService: vi.fn(),
+  getServer: vi.fn(),
+  RESTARTABLE_SERVICES: ["nginx", "php", "mysql", "postgres", "redis", "supervisor"],
+}));
+
+// Resolve numeric server IDs without an API call.
+vi.mock("../../utils/resolve.ts", () => ({
+  resolveServerId: vi.fn(async (value: string) => value),
+}));
+
+const mockRows = [
+  { service: "nginx", available: true, detail: null },
+  { service: "php", available: true, detail: "php83" },
+];
+
+describe("servicesList", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should list services (json)", async () => {
+    const { listServices } = await import("@studiometa/forge-core");
+    vi.mocked(listServices).mockResolvedValue({ data: mockRows });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await servicesList(["10"], ctx);
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("php83"));
+  });
+
+  it("should render human lineFormat", async () => {
+    const { listServices } = await import("@studiometa/forge-core");
+    vi.mocked(listServices).mockResolvedValue({ data: mockRows });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human" },
+    });
+
+    await servicesList(["10"], ctx);
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(""))
+      .join("\n");
+    expect(output).toContain("nginx");
+    expect(output).toContain("php");
+    expect(output).toContain("(php83)");
+  });
+
+  it("should exit with error when no server", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await servicesList([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("servicesRestart", () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should restart a service", async () => {
+    const { restartService } = await import("@studiometa/forge-core");
+    vi.mocked(restartService).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human" },
+    });
+
+    await servicesRestart(["10", "nginx"], ctx);
+    expect(vi.mocked(restartService)).toHaveBeenCalledWith(
+      { server_id: "10", service: "nginx", version: undefined },
+      expect.anything(),
+    );
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(
+      expect.stringContaining("restart initiated"),
+    );
+  });
+
+  it("should restart php with an explicit --version", async () => {
+    const { restartService, getServer } = await import("@studiometa/forge-core");
+    vi.mocked(restartService).mockResolvedValue({ data: undefined as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human", version: "php83" },
+    });
+
+    await servicesRestart(["10", "php"], ctx);
+    expect(vi.mocked(getServer)).not.toHaveBeenCalled();
+    expect(vi.mocked(restartService)).toHaveBeenCalledWith(
+      { server_id: "10", service: "php", version: "php83" },
+      expect.anything(),
+    );
+  });
+
+  it("should default php version from the server", async () => {
+    const { restartService, getServer } = await import("@studiometa/forge-core");
+    vi.mocked(restartService).mockResolvedValue({ data: undefined as never });
+    vi.mocked(getServer).mockResolvedValue({ data: { php_version: "php82" } as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "human" },
+    });
+
+    await servicesRestart(["10", "php"], ctx);
+    expect(vi.mocked(restartService)).toHaveBeenCalledWith(
+      { server_id: "10", service: "php", version: "php82" },
+      expect.anything(),
+    );
+  });
+
+  it("should exit when php has no version and none can be defaulted", async () => {
+    const { getServer, restartService } = await import("@studiometa/forge-core");
+    vi.mocked(getServer).mockResolvedValue({ data: { php_version: null } as never });
+
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await servicesRestart(["10", "php"], ctx).catch(() => {});
+    expect(vi.mocked(restartService)).not.toHaveBeenCalled();
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit for an invalid service", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await servicesRestart(["10", "apache"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit when no server", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await servicesRestart([], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit when no service", async () => {
+    const ctx = createTestContext({
+      token: "test",
+      mockClient: {} as never,
+      options: { format: "json" },
+    });
+
+    await servicesRestart(["10"], ctx).catch(() => {});
+    expect(processExitSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/cli/src/commands/services/handlers.ts
+++ b/packages/cli/src/commands/services/handlers.ts
@@ -1,0 +1,83 @@
+import {
+  getServer,
+  listServices,
+  restartService,
+  RESTARTABLE_SERVICES,
+} from "@studiometa/forge-core";
+
+import type { CommandContext } from "../../context.ts";
+
+import { ValidationError } from "../../errors.ts";
+import { exitWithValidationError, runCommand } from "../../error-handler.ts";
+import { resolveServerId } from "../../utils/resolve.ts";
+
+/**
+ * List services on a server with a derived availability flag.
+ */
+export async function servicesList(args: string[], ctx: CommandContext): Promise<void> {
+  const [server] = args;
+
+  if (!server) {
+    exitWithValidationError("server", "forge services list <server>", ctx.formatter);
+  }
+
+  await runCommand(async () => {
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const server_id = await resolveServerId(server, execCtx);
+    const result = await listServices({ server_id }, execCtx);
+    ctx.formatter.outputList(
+      result.data,
+      ["service", "available", "detail"],
+      "No services.",
+      (row) => {
+        const status = row.available ? "yes" : "no";
+        const detail = row.detail ? ` (${row.detail})` : "";
+        return `${row.service.padEnd(12)}${status}${detail}`;
+      },
+    );
+  }, ctx.formatter);
+}
+
+/**
+ * Restart a service on a server.
+ */
+export async function servicesRestart(args: string[], ctx: CommandContext): Promise<void> {
+  const [server, service] = args;
+
+  if (!server) {
+    exitWithValidationError("server", "forge services restart <server> <service>", ctx.formatter);
+  }
+
+  if (!service) {
+    exitWithValidationError("service", "forge services restart <server> <service>", ctx.formatter);
+  }
+
+  const version = ctx.options.version ? String(ctx.options.version) : undefined;
+
+  await runCommand(async () => {
+    if (!(RESTARTABLE_SERVICES as readonly string[]).includes(service)) {
+      throw new ValidationError(`Invalid service "${service}"`, "service", [
+        `Valid services: ${RESTARTABLE_SERVICES.join(", ")}`,
+      ]);
+    }
+
+    const token = ctx.getToken();
+    const execCtx = ctx.createExecutorContext(token);
+    const server_id = await resolveServerId(server, execCtx);
+
+    let resolvedVersion = version;
+    if (service === "php" && !resolvedVersion) {
+      const { data: srv } = await getServer({ server_id }, execCtx);
+      if (!srv.php_version) {
+        throw new ValidationError("The php service requires a version", "version", [
+          "Pass --version <php_version> (e.g. --version php83)",
+        ]);
+      }
+      resolvedVersion = srv.php_version;
+    }
+
+    await restartService({ server_id, service, version: resolvedVersion }, execCtx);
+    ctx.formatter.success(`${service} restart initiated on server ${server_id}.`);
+  }, ctx.formatter);
+}

--- a/packages/cli/src/commands/services/help.test.ts
+++ b/packages/cli/src/commands/services/help.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { showServicesHelp } from "./help.ts";
+
+describe("showServicesHelp", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should show general help", () => {
+    showServicesHelp();
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("services"));
+  });
+
+  it("should show list help", () => {
+    showServicesHelp("list");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("services list"));
+  });
+
+  it("should show list help for ls", () => {
+    showServicesHelp("ls");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("services list"));
+  });
+
+  it("should show restart help", () => {
+    showServicesHelp("restart");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("services restart"));
+  });
+
+  it("should mention --version for restart", () => {
+    showServicesHelp("restart");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("--version"));
+  });
+});

--- a/packages/cli/src/commands/services/help.ts
+++ b/packages/cli/src/commands/services/help.ts
@@ -1,0 +1,59 @@
+import { colors } from "../../utils/colors.ts";
+
+export function showServicesHelp(subcommand?: string): void {
+  if (subcommand === "list" || subcommand === "ls") {
+    console.log(`
+${colors.bold("forge services list")} - List services on a server
+
+${colors.bold("USAGE:")}
+  forge services list <server> [options]
+
+${colors.bold("ARGUMENTS:")}
+  <server>            Server ID or name (required)
+
+${colors.bold("NOTES:")}
+  Availability is a heuristic derived from the server object — the API has
+  no services listing endpoint.
+
+${colors.bold("EXAMPLES:")}
+  forge services list 123
+  forge services list my-server --format json
+`);
+  } else if (subcommand === "restart") {
+    console.log(`
+${colors.bold("forge services restart")} - Restart a service on a server
+
+${colors.bold("USAGE:")}
+  forge services restart <server> <service> [options]
+
+${colors.bold("ARGUMENTS:")}
+  <server>            Server ID or name (required)
+  <service>           One of: nginx, php, mysql, postgres, redis, supervisor
+
+${colors.bold("OPTIONS:")}
+  --version <ver>     PHP version (e.g. php83) — required for the php service
+                        (defaults to the server's php_version when omitted)
+
+${colors.bold("EXAMPLES:")}
+  forge services restart 123 nginx
+  forge services restart 123 php --version php83
+`);
+  } else {
+    console.log(`
+${colors.bold("forge services")} - List and restart server services
+
+${colors.bold("USAGE:")}
+  forge services <subcommand> [options]
+
+${colors.bold("SUBCOMMANDS:")}
+  list, ls            List services on a server
+  restart <service>   Restart a service (nginx, php, mysql, postgres, redis, supervisor)
+
+${colors.bold("OPTIONS:")}
+  --version <ver>     PHP version (for the php service)
+  -f, --format <fmt>  Output format: json, human, table
+
+Run ${colors.cyan("forge services <subcommand> --help")} for details.
+`);
+  }
+}

--- a/packages/cli/src/commands/services/index.ts
+++ b/packages/cli/src/commands/services/index.ts
@@ -1,0 +1,2 @@
+export { handleServicesCommand } from "./command.ts";
+export { showServicesHelp } from "./help.ts";

--- a/packages/core/src/constants.test.ts
+++ b/packages/core/src/constants.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import { ACTIONS, RESOURCES } from "./constants.ts";
 
 describe("constants", () => {
-  it("should export RESOURCES array with all 21 implemented resources", () => {
-    expect(RESOURCES).toHaveLength(21);
+  it("should export RESOURCES array with all 22 implemented resources", () => {
+    expect(RESOURCES).toHaveLength(22);
     expect(RESOURCES).toContain("servers");
     expect(RESOURCES).toContain("sites");
     expect(RESOURCES).toContain("deployments");
@@ -24,6 +24,7 @@ describe("constants", () => {
     expect(RESOURCES).toContain("backups");
     expect(RESOURCES).toContain("commands");
     expect(RESOURCES).toContain("scheduled-jobs");
+    expect(RESOURCES).toContain("services");
     expect(RESOURCES).toContain("user");
     expect(RESOURCES).toContain("batch");
   });

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -22,6 +22,7 @@ export const RESOURCES = [
   "backups",
   "commands",
   "scheduled-jobs",
+  "services",
   "user",
   "batch",
 ] as const;

--- a/packages/core/src/executors/services/index.ts
+++ b/packages/core/src/executors/services/index.ts
@@ -1,0 +1,9 @@
+export { listServices } from "./list.ts";
+export { restartService } from "./restart.ts";
+export { RESTARTABLE_SERVICES } from "./types.ts";
+export type {
+  ListServicesOptions,
+  RestartableService,
+  RestartServiceOptions,
+  ServiceStatus,
+} from "./types.ts";

--- a/packages/core/src/executors/services/list.test.ts
+++ b/packages/core/src/executors/services/list.test.ts
@@ -1,0 +1,101 @@
+import type { ServerAttributes } from "@studiometa/forge-api";
+import { describe, expect, it, vi } from "vitest";
+
+import { createTestExecutorContext } from "../../context.ts";
+import { mockDocument } from "../../test-helpers.ts";
+import { listServices } from "./list.ts";
+
+function makeServer(overrides: Partial<ServerAttributes> = {}): ServerAttributes {
+  return {
+    id: 1,
+    credential_id: 1,
+    name: "web-1",
+    type: "app",
+    ubuntu_version: "22.04",
+    ssh_port: 22,
+    provider: "ocean2",
+    identifier: null,
+    size: "01",
+    region: "ams3",
+    php_version: "php83",
+    php_cli_version: "php83",
+    opcache_status: null,
+    database_type: "mysql8",
+    db_status: null,
+    redis_status: "installed",
+    ip_address: "1.2.3.4",
+    private_ip_address: null,
+    revoked: false,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    connection_status: "connected",
+    timezone: "UTC",
+    local_public_key: null,
+    is_ready: true,
+    ...overrides,
+  };
+}
+
+function contextForServer(server: ServerAttributes) {
+  const getMock = vi.fn(async () => mockDocument(server.id, "servers", server));
+  const ctx = createTestExecutorContext({
+    client: { get: getMock } as never,
+    organizationSlug: "test-org",
+  });
+  return { ctx, getMock };
+}
+
+describe("listServices", () => {
+  it("should derive availability for a mysql + redis + php server", async () => {
+    const { ctx, getMock } = contextForServer(makeServer());
+
+    const result = await listServices({ server_id: "1" }, ctx);
+
+    expect(getMock).toHaveBeenCalledWith("/orgs/test-org/servers/1");
+    expect(result.data).toEqual([
+      { service: "nginx", available: true, detail: null },
+      { service: "php", available: true, detail: "php83" },
+      { service: "mysql", available: true, detail: "mysql8" },
+      { service: "postgres", available: false, detail: null },
+      { service: "redis", available: true, detail: "installed" },
+      { service: "supervisor", available: true, detail: null },
+    ]);
+  });
+
+  it("should mark postgres available and mysql unavailable for a postgres server", async () => {
+    const { ctx } = contextForServer(
+      makeServer({ database_type: "postgres15", redis_status: null, php_version: null }),
+    );
+
+    const result = await listServices({ server_id: "1" }, ctx);
+    const byName = Object.fromEntries(result.data.map((r) => [r.service, r]));
+
+    expect(byName.php).toEqual({ service: "php", available: false, detail: null });
+    expect(byName.mysql).toEqual({ service: "mysql", available: false, detail: null });
+    expect(byName.postgres).toEqual({
+      service: "postgres",
+      available: true,
+      detail: "postgres15",
+    });
+    expect(byName.redis).toEqual({ service: "redis", available: false, detail: null });
+  });
+
+  it("should treat mariadb as mysql", async () => {
+    const { ctx } = contextForServer(makeServer({ database_type: "mariadb106" }));
+
+    const result = await listServices({ server_id: "1" }, ctx);
+    const mysql = result.data.find((r) => r.service === "mysql");
+
+    expect(mysql).toEqual({ service: "mysql", available: true, detail: "mariadb106" });
+  });
+
+  it("should handle a server with no database type", async () => {
+    const { ctx } = contextForServer(makeServer({ database_type: null }));
+
+    const result = await listServices({ server_id: "1" }, ctx);
+    const byName = Object.fromEntries(result.data.map((r) => [r.service, r]));
+
+    expect(byName.mysql.available).toBe(false);
+    expect(byName.postgres.available).toBe(false);
+  });
+});

--- a/packages/core/src/executors/services/list.ts
+++ b/packages/core/src/executors/services/list.ts
@@ -1,0 +1,57 @@
+import type { ExecutorContext, ExecutorResult } from "../../context.ts";
+import { getServer } from "../servers/get.ts";
+
+import type { ListServicesOptions, ServiceStatus } from "./types.ts";
+
+/**
+ * List services on a server with a derived availability flag.
+ *
+ * The v2 API has no GET endpoint for services, so availability is inferred from
+ * the server object attributes. This `available` flag is a documented heuristic:
+ *
+ * - nginx      → always available
+ * - php        → available when `php_version` is set (detail = php_version)
+ * - mysql      → available when `database_type` starts with "mysql"/"mariadb"
+ * - postgres   → available when `database_type` starts with "postgres"
+ * - redis      → available when `redis_status` is non-null
+ * - supervisor → always available
+ */
+export async function listServices(
+  options: ListServicesOptions,
+  ctx: ExecutorContext,
+): Promise<ExecutorResult<ServiceStatus[]>> {
+  const { data: server } = await getServer({ server_id: options.server_id }, ctx);
+
+  const databaseType = server.database_type ?? "";
+  const isMysql = databaseType.startsWith("mysql") || databaseType.startsWith("mariadb");
+  const isPostgres = databaseType.startsWith("postgres");
+
+  const rows: ServiceStatus[] = [
+    { service: "nginx", available: true, detail: null },
+    {
+      service: "php",
+      available: server.php_version !== null,
+      detail: server.php_version,
+    },
+    {
+      service: "mysql",
+      available: isMysql,
+      detail: isMysql ? server.database_type : null,
+    },
+    {
+      service: "postgres",
+      available: isPostgres,
+      detail: isPostgres ? server.database_type : null,
+    },
+    {
+      service: "redis",
+      available: server.redis_status !== null,
+      detail: server.redis_status,
+    },
+    { service: "supervisor", available: true, detail: null },
+  ];
+
+  return {
+    data: rows,
+  };
+}

--- a/packages/core/src/executors/services/restart.test.ts
+++ b/packages/core/src/executors/services/restart.test.ts
@@ -46,4 +46,17 @@ describe("restartService", () => {
     );
     expect(postMock).not.toHaveBeenCalled();
   });
+
+  it("should throw locally when php is restarted without a version", async () => {
+    const postMock = vi.fn(async () => {});
+    const ctx = createTestExecutorContext({
+      client: { post: postMock } as never,
+      organizationSlug: "test-org",
+    });
+
+    await expect(restartService({ server_id: "1", service: "php" }, ctx)).rejects.toThrow(
+      /"php" service requires a version/,
+    );
+    expect(postMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/executors/services/restart.test.ts
+++ b/packages/core/src/executors/services/restart.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTestExecutorContext } from "../../context.ts";
+import { restartService } from "./restart.ts";
+
+describe("restartService", () => {
+  it("should restart a service via the reboot action", async () => {
+    const postMock = vi.fn(async () => {});
+    const ctx = createTestExecutorContext({
+      client: { post: postMock } as never,
+      organizationSlug: "test-org",
+    });
+
+    const result = await restartService({ server_id: "1", service: "nginx" }, ctx);
+
+    expect(postMock).toHaveBeenCalledWith("/orgs/test-org/servers/1/services/nginx/actions", {
+      action: "reboot",
+    });
+    expect(result.data).toBeUndefined();
+  });
+
+  it("should include the version in the body for php", async () => {
+    const postMock = vi.fn(async () => {});
+    const ctx = createTestExecutorContext({
+      client: { post: postMock } as never,
+      organizationSlug: "test-org",
+    });
+
+    await restartService({ server_id: "1", service: "php", version: "php83" }, ctx);
+
+    expect(postMock).toHaveBeenCalledWith("/orgs/test-org/servers/1/services/php/actions", {
+      action: "reboot",
+      version: "php83",
+    });
+  });
+
+  it("should throw a clear error for an invalid service", async () => {
+    const postMock = vi.fn(async () => {});
+    const ctx = createTestExecutorContext({
+      client: { post: postMock } as never,
+      organizationSlug: "test-org",
+    });
+
+    await expect(restartService({ server_id: "1", service: "apache" }, ctx)).rejects.toThrow(
+      /Invalid service "apache"/,
+    );
+    expect(postMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/executors/services/restart.ts
+++ b/packages/core/src/executors/services/restart.ts
@@ -1,0 +1,38 @@
+import type { ExecutorContext, ExecutorResult } from "../../context.ts";
+import { ROUTES, request } from "../../routes.ts";
+
+import { RESTARTABLE_SERVICES, type RestartServiceOptions } from "./types.ts";
+
+/**
+ * Restart a service on a server.
+ *
+ * Maps the user verb "restart" to the API action "reboot". The v2 API restarts
+ * a service via POST /servers/{server}/services/{service}/actions with body
+ * `{ action: "reboot" }`. The php service additionally requires a `version`.
+ */
+export async function restartService(
+  options: RestartServiceOptions,
+  ctx: ExecutorContext,
+): Promise<ExecutorResult<void>> {
+  if (!(RESTARTABLE_SERVICES as readonly string[]).includes(options.service)) {
+    throw new Error(
+      `Invalid service "${options.service}". Valid services: ${RESTARTABLE_SERVICES.join(", ")}.`,
+    );
+  }
+
+  await request(
+    ROUTES.services.action,
+    ctx,
+    { server_id: options.server_id, service: options.service },
+    {
+      body: {
+        action: "reboot",
+        ...(options.version ? { version: options.version } : {}),
+      },
+    },
+  );
+
+  return {
+    data: undefined,
+  };
+}

--- a/packages/core/src/executors/services/restart.ts
+++ b/packages/core/src/executors/services/restart.ts
@@ -20,6 +20,10 @@ export async function restartService(
     );
   }
 
+  if (options.service === "php" && !options.version) {
+    throw new Error('The "php" service requires a version (e.g. "php83") to restart.');
+  }
+
   await request(
     ROUTES.services.action,
     ctx,

--- a/packages/core/src/executors/services/types.ts
+++ b/packages/core/src/executors/services/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Option and result types for service executors.
+ */
+
+/**
+ * The six restartable services exposed by the Forge v2 API.
+ *
+ * There is no GET endpoint for services — availability is inferred from the
+ * server object (see `listServices`).
+ */
+export const RESTARTABLE_SERVICES = [
+  "nginx",
+  "php",
+  "mysql",
+  "postgres",
+  "redis",
+  "supervisor",
+] as const;
+
+export type RestartableService = (typeof RESTARTABLE_SERVICES)[number];
+
+/**
+ * Options for restarting a service on a server.
+ */
+export interface RestartServiceOptions {
+  server_id: string;
+  /** One of the six restartable services. */
+  service: string;
+  /** PHP version (e.g. "php83") — required when restarting the php service. */
+  version?: string;
+}
+
+/**
+ * Options for listing services on a server.
+ */
+export interface ListServicesOptions {
+  server_id: string;
+}
+
+/**
+ * A single service availability row.
+ *
+ * `available` is a documented heuristic derived from the server attributes,
+ * since the API has no services GET endpoint.
+ */
+export interface ServiceStatus {
+  service: string;
+  available: boolean;
+  detail: string | null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -286,6 +286,15 @@ export type {
   ListScheduledJobsOptions,
 } from "./executors/scheduled-jobs/index.ts";
 
+// Services
+export { listServices, restartService, RESTARTABLE_SERVICES } from "./executors/services/index.ts";
+export type {
+  ListServicesOptions,
+  RestartableService,
+  RestartServiceOptions,
+  ServiceStatus,
+} from "./executors/services/index.ts";
+
 // User
 export { getUser } from "./executors/user/index.ts";
 export type { GetUserOptions } from "./executors/user/index.ts";

--- a/packages/core/src/routes.conformance.test.ts
+++ b/packages/core/src/routes.conformance.test.ts
@@ -32,8 +32,24 @@ describe("Route conformance with OpenAPI spec", () => {
   // user.get is `/user` — exists in spec but not org-scoped
   const routesToCheck = allRoutes;
 
+  // The services action route is parameterized by `:service`, but the OpenAPI
+  // spec enumerates one literal path per restartable service. It is conformant
+  // when every concrete service path exists in the spec.
+  const RESTARTABLE_SERVICES = ["nginx", "php", "mysql", "postgres", "redis", "supervisor"];
+
   for (const { key, route } of routesToCheck) {
     it(`${key} → ${route.method} ${route.path}`, () => {
+      if (key === "services.action") {
+        for (const service of RESTARTABLE_SERVICES) {
+          const concrete = route.path.replace(":service", service);
+          const match = findMatchingSpecPath(concrete);
+          expect(match, `No spec path matches: ${concrete}`).toBeDefined();
+          const methods = Object.keys(spec.paths[match!]).map((m: string) => m.toUpperCase());
+          expect(methods).toContain(route.method);
+        }
+        return;
+      }
+
       const matchingPath = findMatchingSpecPath(route.path);
 
       expect(matchingPath, `No spec path matches: ${route.path}`).toBeDefined();

--- a/packages/core/src/routes.ts
+++ b/packages/core/src/routes.ts
@@ -205,6 +205,12 @@ export const ROUTES = {
       path: "/orgs/:org/servers/:server_id/sites/:site_id/scheduled-jobs/:id/output",
     },
   },
+  services: {
+    action: {
+      method: "POST",
+      path: "/orgs/:org/servers/:server_id/services/:service/actions",
+    },
+  },
   user: {
     get: { method: "GET", path: "/user" },
   },

--- a/packages/mcp/src/formatters.test.ts
+++ b/packages/mcp/src/formatters.test.ts
@@ -58,6 +58,7 @@ import {
   formatSecurityRuleList,
   formatServer,
   formatServerList,
+  formatServiceList,
   formatSite,
   formatSiteList,
   formatSshKey,
@@ -1244,6 +1245,20 @@ describe("formatUser", () => {
 });
 
 // ── Generic helpers ──────────────────────────────────
+
+describe("formatServiceList", () => {
+  it("should format services with availability and detail", () => {
+    const result = formatServiceList([
+      { service: "nginx", available: true, detail: null },
+      { service: "php", available: true, detail: "php83" },
+      { service: "postgres", available: false, detail: null },
+    ]);
+    expect(result).toContain("3 service(s):");
+    expect(result).toContain("• nginx — available");
+    expect(result).toContain("• php — available (php83)");
+    expect(result).toContain("• postgres — unavailable");
+  });
+});
 
 describe("formatDeleted", () => {
   it("should format a deleted confirmation", () => {

--- a/packages/mcp/src/formatters.ts
+++ b/packages/mcp/src/formatters.ts
@@ -515,6 +515,22 @@ export function formatUser(user: UserAttributes & { id: number }): string {
   ].join("\n");
 }
 
+// ── Services ─────────────────────────────────────────
+
+/**
+ * Format a list of services with their derived availability.
+ */
+export function formatServiceList(
+  services: { service: string; available: boolean; detail: string | null }[],
+): string {
+  const lines = services.map((s) => {
+    const status = s.available ? "available" : "unavailable";
+    const detail = s.detail ? ` (${s.detail})` : "";
+    return `• ${s.service} — ${status}${detail}`;
+  });
+  return `${services.length} service(s):\n${lines.join("\n")}`;
+}
+
 // ── Generic helpers ──────────────────────────────────
 
 /**

--- a/packages/mcp/src/handlers/help.ts
+++ b/packages/mcp/src/handlers/help.ts
@@ -358,6 +358,43 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
     ],
   },
 
+  services: {
+    description:
+      "List and restart server services (nginx, php, mysql, postgres, redis, supervisor)",
+    scope: "server (requires server_id)",
+    actions: {
+      list: "List services with a derived availability flag (heuristic — the API has no services GET endpoint)",
+      restart:
+        "Restart a service (maps to the API action reboot). The php service requires a version.",
+    },
+    fields: {
+      service: "One of: nginx, php, mysql, postgres, redis, supervisor",
+      available: "Heuristic derived from the server object attributes",
+      detail: "Extra info (php_version, database_type, redis_status) when relevant",
+      version: "PHP version (e.g. php83) — required when restarting php",
+    },
+    examples: [
+      {
+        description: "List services",
+        params: { resource: "services", action: "list", server_id: "123" },
+      },
+      {
+        description: "Restart nginx",
+        params: { resource: "services", action: "restart", server_id: "123", service: "nginx" },
+      },
+      {
+        description: "Restart php (version required)",
+        params: {
+          resource: "services",
+          action: "restart",
+          server_id: "123",
+          service: "php",
+          version: "php83",
+        },
+      },
+    ],
+  },
+
   "firewall-rules": {
     description: "Manage UFW firewall rules on a server",
     scope: "server (requires server_id)",

--- a/packages/mcp/src/handlers/index.ts
+++ b/packages/mcp/src/handlers/index.ts
@@ -34,6 +34,7 @@ import { handleScheduledJobs } from "./scheduled-jobs.ts";
 import { handleSchema, handleSchemaOverview } from "./schema.ts";
 import { handleSecurityRules } from "./security-rules.ts";
 import { handleServers } from "./servers.ts";
+import { handleServices } from "./services.ts";
 import { handleSites } from "./sites.ts";
 import { handleSshKeys } from "./ssh-keys.ts";
 import { handleUser } from "./user.ts";
@@ -104,6 +105,8 @@ function routeToHandler(
       return handleCommands(action, args, ctx);
     case "scheduled-jobs":
       return handleScheduledJobs(action, args, ctx);
+    case "services":
+      return handleServices(action, args, ctx);
     case "user":
       return handleUser(action, args, ctx);
     case "batch":

--- a/packages/mcp/src/handlers/router.test.ts
+++ b/packages/mcp/src/handlers/router.test.ts
@@ -127,6 +127,42 @@ vi.mock("@studiometa/forge-api", async (importOriginal) => {
             links: { next: null, prev: null },
             meta: { per_page: 30, next_cursor: null, prev_cursor: null },
           };
+        // Single server GET (used by services list to derive availability)
+        if (/\/servers\/\d+$/.test(path))
+          return {
+            data: {
+              id: "1",
+              type: "servers",
+              attributes: {
+                id: 1,
+                credential_id: 1,
+                name: "web-1",
+                type: "app",
+                ubuntu_version: "22.04",
+                ssh_port: 22,
+                provider: "ocean2",
+                identifier: null,
+                size: "01",
+                region: "ams3",
+                php_version: "php83",
+                php_cli_version: "php83",
+                opcache_status: null,
+                database_type: "mysql8",
+                db_status: null,
+                redis_status: "installed",
+                ip_address: "1.2.3.4",
+                private_ip_address: null,
+                revoked: false,
+                created_at: "2024-01-01T00:00:00Z",
+                updated_at: "2024-01-01T00:00:00Z",
+                connection_status: "connected",
+                timezone: "UTC",
+                local_public_key: null,
+                is_ready: true,
+              },
+              links: { self: { href: "/servers/1" } },
+            },
+          };
         // Servers (generic)
         if (path.includes("/servers"))
           return {
@@ -189,6 +225,7 @@ describe("routeToHandler — resource routing coverage", () => {
     { resource: "backups", extra: { server_id: "1" } },
     { resource: "commands", extra: { server_id: "1", site_id: "10" } },
     { resource: "scheduled-jobs", extra: { server_id: "1" } },
+    { resource: "services", extra: { server_id: "1" } },
     { resource: "database-users", extra: { server_id: "1" } },
     { resource: "deployments", extra: { server_id: "1", site_id: "10" } },
   ];

--- a/packages/mcp/src/handlers/schema.ts
+++ b/packages/mcp/src/handlers/schema.ts
@@ -158,6 +158,15 @@ const RESOURCE_SCHEMAS: Record<string, ResourceSchemaData> = {
     },
   },
 
+  services: {
+    actions: ["list", "restart"],
+    scope: "server",
+    required: {
+      list: ["server_id"],
+      restart: ["server_id", "service"],
+    },
+  },
+
   "firewall-rules": {
     actions: ["list", "get", "create", "delete"],
     scope: "server",

--- a/packages/mcp/src/handlers/services.test.ts
+++ b/packages/mcp/src/handlers/services.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { mockDocument } from "@studiometa/forge-core";
+
+import type { HandlerContext } from "./types.ts";
+
+import { handleServices } from "./services.ts";
+
+function makeServerAttrs(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    credential_id: 1,
+    name: "web-1",
+    type: "app",
+    ubuntu_version: "22.04",
+    ssh_port: 22,
+    provider: "ocean2",
+    identifier: null,
+    size: "01",
+    region: "ams3",
+    php_version: "php83",
+    php_cli_version: "php83",
+    opcache_status: null,
+    database_type: "mysql8",
+    db_status: null,
+    redis_status: "installed",
+    ip_address: "1.2.3.4",
+    private_ip_address: null,
+    revoked: false,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    connection_status: "connected",
+    timezone: "UTC",
+    local_public_key: null,
+    is_ready: true,
+    ...overrides,
+  };
+}
+
+function createMockContext(): HandlerContext {
+  return {
+    executorContext: {
+      organizationSlug: "test-org",
+      client: {
+        get: async () => mockDocument(1, "servers", makeServerAttrs()),
+        post: async () => {},
+      } as never,
+    },
+    compact: true,
+  };
+}
+
+describe("handleServices", () => {
+  it("should list services derived from the server object", async () => {
+    const result = await handleServices(
+      "list",
+      { resource: "services", action: "list", server_id: "1" },
+      createMockContext(),
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("nginx");
+    expect(result.content[0].text).toContain("php");
+  });
+
+  it("should restart a service", async () => {
+    const result = await handleServices(
+      "restart",
+      { resource: "services", action: "restart", server_id: "1", service: "nginx" },
+      createMockContext(),
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("nginx restart initiated");
+  });
+
+  it("should restart php with a version", async () => {
+    const result = await handleServices(
+      "restart",
+      {
+        resource: "services",
+        action: "restart",
+        server_id: "1",
+        service: "php",
+        version: "php83",
+      },
+      createMockContext(),
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("php restart initiated");
+  });
+
+  it("should reject an invalid service", async () => {
+    // The core executor throws; executeToolWithCredentials catches it in the real
+    // flow, so calling the handler directly surfaces the rejection.
+    await expect(
+      handleServices(
+        "restart",
+        { resource: "services", action: "restart", server_id: "1", service: "apache" },
+        createMockContext(),
+      ),
+    ).rejects.toThrow(/Invalid service "apache"/);
+  });
+
+  it("should require server_id for list", async () => {
+    const result = await handleServices(
+      "list",
+      { resource: "services", action: "list" },
+      createMockContext(),
+    );
+    expect(result.isError).toBe(true);
+  });
+
+  it("should handle unknown action", async () => {
+    const result = await handleServices(
+      "unknown",
+      { resource: "services", action: "unknown", server_id: "1" },
+      createMockContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Unknown action");
+  });
+});

--- a/packages/mcp/src/handlers/services.ts
+++ b/packages/mcp/src/handlers/services.ts
@@ -1,0 +1,33 @@
+import * as v from "valibot";
+import { listServices, restartService } from "@studiometa/forge-core";
+
+import { formatServiceList } from "../formatters.ts";
+import { createResourceHandler } from "./factory.ts";
+
+export const handleServices = createResourceHandler({
+  resource: "services",
+  actions: ["list", "restart"],
+  inputSchemas: {
+    list: v.object({ server_id: v.string() }),
+    restart: v.object({
+      server_id: v.string(),
+      service: v.string(),
+      version: v.optional(v.string()),
+    }),
+  },
+  executors: {
+    list: listServices,
+    restart: restartService,
+  },
+  formatResult: (action, data, args) => {
+    switch (action) {
+      case "list":
+        return formatServiceList(data);
+      case "restart":
+        return `${String(args.service)} restart initiated on server ${String(args.server_id)}.`;
+      /* v8 ignore next */
+      default:
+        return "Done.";
+    }
+  },
+});

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -293,6 +293,16 @@ const FORGE_WRITE_TOOL: Tool = {
         description: "Server IDs to run a recipe on (e.g. [123, 456])",
         items: { type: "number" as const },
       },
+      // Service fields
+      service: {
+        type: "string" as const,
+        description:
+          "Service to restart (services: nginx, php, mysql, postgres, redis, supervisor)",
+      },
+      version: {
+        type: "string" as const,
+        description: "PHP version required when restarting the php service (e.g. php83)",
+      },
     },
     required: ["resource", "action"],
   },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -34,6 +34,12 @@ export { SecurityRulesCollection } from "./resources/security-rules.ts";
 export type { SecurityRuleListOptions } from "./resources/security-rules.ts";
 export { ServersCollection, ServerResource } from "./resources/servers.ts";
 export type { ServerListOptions, ResolveMatch, ResolveResult } from "./resources/servers.ts";
+export { ServicesCollection, RESTARTABLE_SERVICES } from "./resources/services.ts";
+export type {
+  RestartableService,
+  RestartServiceOptions,
+  ServiceStatus,
+} from "./resources/services.ts";
 export { SshKeysCollection } from "./resources/ssh-keys.ts";
 export type { SshKeyListOptions } from "./resources/ssh-keys.ts";
 export {

--- a/packages/sdk/src/resources/servers.ts
+++ b/packages/sdk/src/resources/servers.ts
@@ -20,6 +20,7 @@ import { MonitorsCollection } from "./monitors.ts";
 import { FirewallRulesCollection } from "./firewall-rules.ts";
 import { SshKeysCollection } from "./ssh-keys.ts";
 import { NginxTemplatesCollection } from "./nginx-templates.ts";
+import { ServicesCollection } from "./services.ts";
 import { BaseCollection } from "./base.ts";
 
 /**
@@ -272,6 +273,9 @@ export class ServerResource extends BaseCollection {
   /** Nginx templates on this server. */
   readonly nginxTemplates: NginxTemplatesCollection;
 
+  /** Services (nginx, php, mysql, etc.) on this server. */
+  readonly services: ServicesCollection;
+
   /** @internal */
   constructor(
     client: HttpClient,
@@ -289,6 +293,7 @@ export class ServerResource extends BaseCollection {
     this.firewallRules = new FirewallRulesCollection(client, orgSlug, serverId);
     this.sshKeys = new SshKeysCollection(client, orgSlug, serverId);
     this.nginxTemplates = new NginxTemplatesCollection(client, orgSlug, serverId);
+    this.services = new ServicesCollection(client, orgSlug, serverId);
   }
 
   /**

--- a/packages/sdk/src/resources/services.test.ts
+++ b/packages/sdk/src/resources/services.test.ts
@@ -127,4 +127,12 @@ describe("ServicesCollection", () => {
 
     await expect(collection.restart("apache")).rejects.toThrow(/Invalid service "apache"/);
   });
+
+  it("should throw when restarting php without a version", async () => {
+    const { client, calls } = createTrackingClient();
+    const collection = new ServicesCollection(client, ORG, 123);
+
+    await expect(collection.restart("php")).rejects.toThrow(/"php" service requires a version/);
+    expect(calls).toHaveLength(0);
+  });
 });

--- a/packages/sdk/src/resources/services.test.ts
+++ b/packages/sdk/src/resources/services.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { HttpClient } from "@studiometa/forge-api";
+
+import { toUrlString } from "../test-utils.ts";
+
+import { ServicesCollection } from "./services.ts";
+
+const ORG = "test-org";
+
+const serverAttrs = {
+  id: 123,
+  credential_id: 1,
+  name: "web-1",
+  type: "app",
+  ubuntu_version: "22.04",
+  ssh_port: 22,
+  provider: "ocean2",
+  identifier: null,
+  size: "01",
+  region: "ams3",
+  php_version: "php83",
+  php_cli_version: "php83",
+  opcache_status: null,
+  database_type: "mysql8",
+  db_status: null,
+  redis_status: "installed",
+  ip_address: "1.2.3.4",
+  private_ip_address: null,
+  revoked: false,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  connection_status: "connected",
+  timezone: "UTC",
+  local_public_key: null,
+  is_ready: true,
+};
+
+function createTrackingClient(overrides: Record<string, unknown> = {}): {
+  client: HttpClient;
+  calls: Array<{ method: string; url: string; body?: unknown }>;
+} {
+  const calls: Array<{ method: string; url: string; body?: unknown }> = [];
+
+  const client = new HttpClient({
+    token: "test",
+    fetch: async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = toUrlString(url);
+      calls.push({
+        method: init?.method ?? "GET",
+        url: urlStr,
+        body: init?.body ? JSON.parse(init.body as string) : undefined,
+      });
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({
+          data: { id: "123", type: "servers", attributes: { ...serverAttrs, ...overrides } },
+        }),
+        text: async () => "{}",
+      } as Response;
+    },
+  });
+
+  return { client, calls };
+}
+
+describe("ServicesCollection", () => {
+  it("should derive service availability from the server object", async () => {
+    const { client, calls } = createTrackingClient();
+    const collection = new ServicesCollection(client, ORG, 123);
+
+    const services = await collection.list();
+
+    expect(calls[0].url).toContain(`/orgs/${ORG}/servers/123`);
+    expect(services).toEqual([
+      { service: "nginx", available: true, detail: null },
+      { service: "php", available: true, detail: "php83" },
+      { service: "mysql", available: true, detail: "mysql8" },
+      { service: "postgres", available: false, detail: null },
+      { service: "redis", available: true, detail: "installed" },
+      { service: "supervisor", available: true, detail: null },
+    ]);
+  });
+
+  it("should derive postgres availability", async () => {
+    const { client } = createTrackingClient({
+      database_type: "postgres15",
+      redis_status: null,
+      php_version: null,
+    });
+    const collection = new ServicesCollection(client, ORG, 123);
+
+    const services = await collection.list();
+    const byName = Object.fromEntries(services.map((s) => [s.service, s]));
+
+    expect(byName.postgres).toEqual({ service: "postgres", available: true, detail: "postgres15" });
+    expect(byName.mysql.available).toBe(false);
+    expect(byName.php.available).toBe(false);
+    expect(byName.redis.available).toBe(false);
+  });
+
+  it("should restart a service via the reboot action", async () => {
+    const { client, calls } = createTrackingClient();
+    const collection = new ServicesCollection(client, ORG, 123);
+
+    await collection.restart("nginx");
+
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toContain(`/orgs/${ORG}/servers/123/services/nginx/actions`);
+    expect(calls[0].body).toEqual({ action: "reboot" });
+  });
+
+  it("should include the version when restarting php", async () => {
+    const { client, calls } = createTrackingClient();
+    const collection = new ServicesCollection(client, ORG, 123);
+
+    await collection.restart("php", { version: "php83" });
+
+    expect(calls[0].body).toEqual({ action: "reboot", version: "php83" });
+  });
+
+  it("should throw for an invalid service", async () => {
+    const { client } = createTrackingClient();
+    const collection = new ServicesCollection(client, ORG, 123);
+
+    await expect(collection.restart("apache")).rejects.toThrow(/Invalid service "apache"/);
+  });
+});

--- a/packages/sdk/src/resources/services.ts
+++ b/packages/sdk/src/resources/services.ts
@@ -121,6 +121,10 @@ export class ServicesCollection extends BaseCollection {
       );
     }
 
+    if (service === "php" && !options.version) {
+      throw new Error('The "php" service requires a version (e.g. "php83") to restart.');
+    }
+
     await this.client.post(`${this.basePath}/services/${service}/actions`, {
       action: "reboot",
       ...(options.version ? { version: options.version } : {}),

--- a/packages/sdk/src/resources/services.ts
+++ b/packages/sdk/src/resources/services.ts
@@ -1,0 +1,129 @@
+import type { HttpClient, JsonApiDocument, ServerAttributes } from "@studiometa/forge-api";
+
+import { unwrapDocument } from "@studiometa/forge-api";
+
+import { BaseCollection } from "./base.ts";
+
+/**
+ * The six restartable services exposed by the Forge v2 API.
+ */
+export const RESTARTABLE_SERVICES = [
+  "nginx",
+  "php",
+  "mysql",
+  "postgres",
+  "redis",
+  "supervisor",
+] as const;
+
+export type RestartableService = (typeof RESTARTABLE_SERVICES)[number];
+
+/**
+ * A single service availability row.
+ *
+ * `available` is a documented heuristic derived from the server object, since
+ * the API has no services GET endpoint.
+ */
+export interface ServiceStatus {
+  service: string;
+  available: boolean;
+  detail: string | null;
+}
+
+/**
+ * Options for restarting a service.
+ */
+export interface RestartServiceOptions {
+  /** PHP version (e.g. "php83") — required when restarting the php service. */
+  version?: string;
+}
+
+/**
+ * Services on a server — list availability and restart individual services.
+ *
+ * Access via `forge.server(id).services`.
+ *
+ * The v2 API has no GET endpoint for services, so `list()` derives availability
+ * from the server object. Restarting maps to the API action `reboot`.
+ *
+ * @example
+ * ```ts
+ * // List services and their availability
+ * const services = await forge.server(123).services.list();
+ *
+ * // Restart nginx
+ * await forge.server(123).services.restart('nginx');
+ *
+ * // Restart php (version required)
+ * await forge.server(123).services.restart('php', { version: 'php83' });
+ * ```
+ */
+export class ServicesCollection extends BaseCollection {
+  /** @internal */
+  constructor(
+    client: HttpClient,
+    orgSlug: string,
+    private readonly serverId: number,
+  ) {
+    super(client, orgSlug);
+  }
+
+  private get basePath(): string {
+    return `/orgs/${this.orgSlug}/servers/${this.serverId}`;
+  }
+
+  /**
+   * List services on this server with a derived availability flag.
+   *
+   * @example
+   * ```ts
+   * const services = await forge.server(123).services.list();
+   * // → [{ service: 'nginx', available: true, detail: null }, ...]
+   * ```
+   */
+  async list(): Promise<ServiceStatus[]> {
+    const response = await this.client.get<JsonApiDocument<ServerAttributes>>(this.basePath);
+    const server = unwrapDocument(response);
+
+    const databaseType = server.database_type ?? "";
+    const isMysql = databaseType.startsWith("mysql") || databaseType.startsWith("mariadb");
+    const isPostgres = databaseType.startsWith("postgres");
+
+    return [
+      { service: "nginx", available: true, detail: null },
+      { service: "php", available: server.php_version !== null, detail: server.php_version },
+      { service: "mysql", available: isMysql, detail: isMysql ? server.database_type : null },
+      {
+        service: "postgres",
+        available: isPostgres,
+        detail: isPostgres ? server.database_type : null,
+      },
+      { service: "redis", available: server.redis_status !== null, detail: server.redis_status },
+      { service: "supervisor", available: true, detail: null },
+    ];
+  }
+
+  /**
+   * Restart a service on this server.
+   *
+   * Maps to the API action `reboot`. The php service requires a `version`.
+   *
+   * @example
+   * ```ts
+   * await forge.server(123).services.restart('nginx');
+   * await forge.server(123).services.restart('php', { version: 'php83' });
+   * ```
+   */
+  async restart(service: string, options: RestartServiceOptions = {}): Promise<void> {
+    if (!(RESTARTABLE_SERVICES as readonly string[]).includes(service)) {
+      throw new Error(
+        `Invalid service "${service}". Valid services: ${RESTARTABLE_SERVICES.join(", ")}.`,
+      );
+    }
+
+    await this.client.post(`${this.basePath}/services/${service}/actions`, {
+      action: "reboot",
+      ...(options.version ? { version: options.version } : {}),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new server-scoped `services` resource to list and restart the six restartable Forge services (nginx, php, mysql, postgres, redis, supervisor), wired through all layers: **core → sdk → mcp → cli**.

## Behaviour notes

- **`restart` maps to the API action `"reboot"`.** The v2 API restarts a service via `POST /orgs/{org}/servers/{server}/services/{service}/actions` with body `{ action: "reboot" }` (the enum value is `reboot`, not `restart`). Responses are `202` with an empty body (async).
- **php requires a version.** Restarting `php` sends `{ version }` (e.g. `php83`). In the CLI, `--version` is optional and defaults to the server's `php_version`; if that is null the command exits with a validation error explaining `--version` is required.
- **`list` availability is a heuristic.** The API has **no GET endpoint for services**, so availability is derived from the server object attributes (`php_version`, `database_type`, `redis_status`); nginx and supervisor are always available. This is documented as a heuristic in the code and help text.

## Layers

- **core** (`executors/services/`): `restartService` (validates the service against the six, builds the reboot body) and `listServices` (derives rows from `getServer`). New `services` group in `ROUTES` and `"services"` in `RESOURCES`.
- **sdk**: `forge.server(id).services.list()` and `forge.server(id).services.restart(service, { version })`.
- **mcp**: `services` resource with read `list` (via `forge`) and write `restart` (via `forge_write`), plus a compact list formatter and help/schema entries.
- **cli**: `forge services list <server>` and `forge services restart <server> <service> [--version]`, registered in dispatch, top-level help, and shell completions (bash/zsh/fish). Server args resolve by ID or name via `resolveServerId`.

Also: the global `-v/--version` guard in `cli.ts` now only fires for a bare flag, so `--version <php_version>` falls through to the services command instead of printing the CLI version.

## Testing

`build`, `typecheck`, `lint`, `format:check`, and the full test suite (1942 tests) all pass. Every new source file has colocated tests; the route conformance and router-coverage tests were extended for the parameterized services path.

## Merge note

Branched from `main` independently of PR A. `CHANGELOG.md` and a few `index.ts` exports may need trivial add-only conflict resolution at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)