### PR TITLE
feat: forward CODE_REVIEW_* config (enable OpenTelemetry org-wide)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -13,18 +13,25 @@ jobs:
     runs-on: ubuntu-latest
     # Same-repo PRs only: fork PRs don't receive secrets on pull_request.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    # Provider creds (org secrets) + review settings (org variables). The
-    # CODE_REVIEW_ prefix on the credentials is de-prefixed to CLOUDFLARE_* by
-    # the CLI's env shim. Referenced directly here (not via a cross-org reusable
-    # workflow) because `secrets: inherit` does not carry org secrets across orgs.
-    env:
-      CODE_REVIEW_CLOUDFLARE_API_KEY: ${{ secrets.CODE_REVIEW_CLOUDFLARE_API_KEY }}
-      CODE_REVIEW_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CODE_REVIEW_CLOUDFLARE_ACCOUNT_ID }}
-      CODE_REVIEW_CLOUDFLARE_GATEWAY_ID: ${{ secrets.CODE_REVIEW_CLOUDFLARE_GATEWAY_ID }}
-      CODE_REVIEW_DEPTH: ${{ vars.CODE_REVIEW_DEPTH }}
-      CODE_REVIEW_THINKING_LEVEL: ${{ vars.CODE_REVIEW_THINKING_LEVEL }}
-      CODE_REVIEW_VERIFY_MODEL: ${{ vars.CODE_REVIEW_VERIFY_MODEL }}
     steps:
+      # Forward the whole CODE_REVIEW_* namespace (review settings, provider
+      # credentials, OpenTelemetry) from org/repo variables + secrets. GitHub
+      # doesn't auto-inject org config as env; the composite action inherits
+      # whatever lands in $GITHUB_ENV. New options are configured purely at the
+      # org level with no change here. The CLI reads CODE_REVIEW_* directly and
+      # de-prefixes CODE_REVIEW_<PROVIDER>_* creds and CODE_REVIEW_OTEL_* → OTEL_*.
+      - name: Forward CODE_REVIEW_* config
+        env:
+          CR_VARS: ${{ toJSON(vars) }}
+          CR_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          emit() {
+            jq -r 'to_entries[]
+                   | select(.key | test("^CODE_REVIEW_"; "i"))
+                   | "\(.key)<<CR_EOF\n\(.value)\nCR_EOF"' <<<"$1" >> "$GITHUB_ENV"
+          }
+          emit "$CR_VARS"
+          emit "$CR_SECRETS"
       # The composite action checks out the repo itself (checkout: true default).
       - uses: weareikko/code-review@7a733e03c790e5dc54c2962560857e6ceb7e3e61 # 0.8.2
         with:


### PR DESCRIPTION
Same change already merged into studiometa/ui (#544) and js-toolkit (#747): a step that forwards the whole `CODE_REVIEW_*` namespace (settings, provider creds, OpenTelemetry) from org/repo vars + secrets into the review job. GitHub doesn't auto-inject org config as env, so without this the org-level OTel config isn't picked up. No-op until the org config exists (it does). Composite action ref unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)